### PR TITLE
Building Cairo.jl for AWS Lambda

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -11,7 +11,7 @@ ignore_system_font_libs(n, h) = !(haskey(ENV, "JULIA_BINDEPS_IGNORE_SYSTEM_FONT_
 
 deps = [
     libffi = library_dependency("ffi", aliases = ["libffi"], group = group1)
-    gobject = library_dependency("gobject", aliases = ["libgobject-2.0-0", "libgobject-2.0", "libgobject-2_0-0", "libgobject-2.0.so.0"], depends=[libffi], group = group1)
+    gobject = library_dependency("gobject", aliases = ["libgobject-2.0.so.0", "libgobject-2.0-0", "libgobject-2.0", "libgobject-2_0-0"], depends=[libffi], group = group1)
     zlib = library_dependency("zlib", aliases = ["libzlib","zlib1"], os = :Windows, group = group1)
     libpng = library_dependency("png", aliases = ["libpng","libpng-1.5.14","libpng15","libpng12.so.0"], group = group1)
     pixman = library_dependency("pixman", aliases = ["libpixman","libpixman-1","libpixman-1-0","libpixman-1.0"], depends = [libpng], group = group1)


### PR DESCRIPTION
See #133 

Amazon Linux on the Lambda sandbox meets some of Cairo.jl's dependancies with system libraries.
There is no way to install new system libraries (i.e. no root access and no yum). 
`freetype` and `fontconfig` are installed as system libraries but the versions are too old for `pango`.

This PR allows Cairo.jl to use the system versions of `libgobject`, `libffi`, `libpng` and `libpixman`, while everything else is built form source.

The commits make one change at a time:
- Remove runtime = false for libraries that are required at runtime (see ldd output in #133).
- remove gettext (nothing depends on it)
- Add harfbuzz (required by pango)
- Update libfontconfig version. (and don't try to build libfontconfig against expat).
- add option JULIA_BINDEPS_DISABLE_SYSTEM_PACKAGE_MANAGERS
- add option JULIA_BINDEPS_IGNORE_SYSTEM_FONT_LIBS
- split dependancies into two groups (otherwise no `@checked_lib` statements are generated in `deps.jl`).

The resulting `deps.jl` contains this:

``` julia
@checked_lib _jl_libgobject "/usr/lib64/libgobject-2.0.so"
@checked_lib _jl_libpango "/var/task/julia/v0.4/Cairo/deps/usr/lib/libpango-1.0.so"
@checked_lib _jl_libpangocairo "/var/task/julia/v0.4/Cairo/deps/usr/lib/libpangocairo-1.0.so"
@checked_lib _jl_libcairo "/var/task/julia/v0.4/Cairo/deps/usr/lib/libcairo.so"
```
