### PR TITLE
Allow RGB24/ARGB32 eltype in CairoSurface; fix depwarns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/JuliaLang/Cairo.jl.svg)](https://travis-ci.org/JuliaLang/Cairo.jl)
+[![Build Status](https://travis-ci.org/JuliaGraphics/Cairo.jl.svg)](https://travis-ci.org/JuliaGraphics/Cairo.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/mpuhyoy9ew187f08/branch/master?svg=true)](https://ci.appveyor.com/project/tkelman/cairo-jl/branch/master)
 
 [![Cairo](http://pkg.julialang.org/badges/Cairo_0.3.svg)](http://pkg.julialang.org/?pkg=Cairo&ver=0.3)

--- a/samples/sample_rounded_rectangle.jl
+++ b/samples/sample_rounded_rectangle.jl
@@ -15,18 +15,18 @@ save(cr);
 # a custom shape that could be wrapped in a function */
 x         = 25.6;        # parameters like cairo_rectangle */
 y         = 25.6;
-width         = 204.8;
-height        = 204.8;
+xw         = 204.8;
+yw        = 204.8;
 aspect        = 1.0;     # aspect ratio */
-corner_radius = height / 10.0;   #* and corner curvature radius */
+corner_radius = yw / 10.0;   #* and corner curvature radius */
 
 radius = corner_radius / aspect;
 degrees = pi / 180.0;
 
 new_sub_path(cr);
-arc(cr, x + width - radius, y + radius, radius, -90 * degrees, 0 * degrees);
-arc(cr, x + width - radius, y + height - radius, radius, 0 * degrees, 90 * degrees);
-arc(cr, x + radius, y + height - radius, radius, 90 * degrees, 180 * degrees);
+arc(cr, x + xw - radius, y + radius, radius, -90 * degrees, 0 * degrees);
+arc(cr, x + xw - radius, y + yw - radius, radius, 0 * degrees, 90 * degrees);
+arc(cr, x + radius, y + yw - radius, radius, 90 * degrees, 180 * degrees);
 arc(cr, x + radius, y + radius, radius, 180 * degrees, 270 * degrees);
 close_path(cr);
 

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -614,7 +614,7 @@ function convert_cairo_path_data(p::CairoPath)
     # define here by Float64 (most data is) and reinterpret in the header.
 
     path_data = CairoPathEntry[]
-    c_data = pointer_to_array(c.data,(c.num_data*2,1),true)
+    c_data = @compat unsafe_wrap(Array,c.data,(c.num_data*2,1),true)
 
     data_index = 1
     while data_index <= ((c.num_data)*2)

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -214,7 +214,7 @@ end
 
 function CairoPDFSurface(filename::AbstractString, w_pts::Real, h_pts::Real)
     ptr = ccall((:cairo_pdf_surface_create,_jl_libcairo), Ptr{Void},
-                (Ptr{UInt8},Float64,Float64), bytestring(filename), w_pts, h_pts)
+                (Ptr{UInt8},Float64,Float64), @compat(String(filename)), w_pts, h_pts)
     CairoSurface(ptr, w_pts, h_pts)
 end
 
@@ -240,7 +240,7 @@ end
 
 function CairoEPSSurface(filename::AbstractString, w_pts::Real, h_pts::Real)
     ptr = ccall((:cairo_ps_surface_create,_jl_libcairo), Ptr{Void},
-                (Ptr{UInt8},Float64,Float64), bytestring(filename), w_pts, h_pts)
+                (Ptr{UInt8},Float64,Float64), @compat(String(filename)), w_pts, h_pts)
     ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Void,
           (Ptr{Void},Int32), ptr, 1)
     CairoSurface(ptr, w_pts, h_pts)
@@ -293,7 +293,7 @@ end
 
 function CairoSVGSurface(filename::AbstractString, w::Real, h::Real)
     ptr = ccall((:cairo_svg_surface_create,_jl_libcairo), Ptr{Void},
-                (Ptr{UInt8},Float64,Float64), bytestring(filename), w, h)
+                (Ptr{UInt8},Float64,Float64), @compat(String(filename)), w, h)
     CairoSurface(ptr, w, h)
 end
 
@@ -301,7 +301,7 @@ end
 
 function read_from_png(filename::AbstractString)
     ptr = ccall((:cairo_image_surface_create_from_png,_jl_libcairo),
-                Ptr{Void}, (Ptr{UInt8},), bytestring(filename))
+                Ptr{Void}, (Ptr{UInt8},), @compat(String(filename)))
     w = ccall((:cairo_image_surface_get_width,_jl_libcairo),
               Int32, (Ptr{Void},), ptr)
     h = ccall((:cairo_image_surface_get_height,_jl_libcairo),
@@ -323,10 +323,10 @@ end
 
 function write_to_png(surface::CairoSurface, filename::AbstractString)
     ccall((:cairo_surface_write_to_png,_jl_libcairo), Void,
-          (Ptr{UInt8},Ptr{UInt8}), surface.ptr, bytestring(filename))
+          (Ptr{UInt8},Ptr{UInt8}), surface.ptr, @compat(String(filename)))
 end
 
-writemime(io::IO, ::MIME"image/png", surface::CairoSurface) =
+@compat Base.show(io::IO, ::MIME"image/png", surface::CairoSurface) =
    write_to_png(surface, io)
 
 ## Generic ##
@@ -555,7 +555,6 @@ end
 function set_source(ctx::CairoContext, s::CairoSurface, x::Real, y::Real)
     set_source_surface(ctx, s, x, y)
 end
-set_source(ctx::CairoContext, s::CairoSurface) = set_source_surface(ctx, s, 0, 0)
 
 
 # cairo_path data and functions
@@ -868,7 +867,7 @@ end
 
 function set_font_face(ctx::CairoContext, str::AbstractString)
     fontdesc = ccall((:pango_font_description_from_string,_jl_libpango),
-                     Ptr{Void}, (Ptr{UInt8},), bytestring(str))
+                     Ptr{Void}, (Ptr{UInt8},), @compat(String(str)))
     ccall((:pango_layout_set_font_description,_jl_libpango), Void,
           (Ptr{Void},Ptr{Void}), ctx.layout, fontdesc)
     ccall((:pango_font_description_free,_jl_libpango), Void,
@@ -878,10 +877,10 @@ end
 function set_text(ctx::CairoContext, text::AbstractString, markup::Bool = false)
     if markup
         ccall((:pango_layout_set_markup,_jl_libpango), Void,
-            (Ptr{Void},Ptr{UInt8},Int32), ctx.layout, bytestring(text), -1)
+            (Ptr{Void},Ptr{UInt8},Int32), ctx.layout, @compat(String(text)), -1)
     else
         ccall((:pango_layout_set_text,_jl_libpango), Void,
-            (Ptr{Void},Ptr{UInt8},Int32), ctx.layout, bytestring(text), -1)
+            (Ptr{Void},Ptr{UInt8},Int32), ctx.layout, @compat(String(text)), -1)
     end
     text
 end
@@ -908,7 +907,7 @@ text_extents(ctx::CairoContext,value::AbstractString) = text_extents!(ctx,value,
 function text_extents!(ctx::CairoContext,value::AbstractString,extents)
     ccall((:cairo_text_extents, _jl_libcairo),
           Void, (Ptr{Void}, Ptr{UInt8}, Ptr{Float64}),
-          ctx.ptr, bytestring(value), extents)
+          ctx.ptr, @compat(String(value)), extents)
     extents
 end
 
@@ -930,13 +929,13 @@ end
 function show_text(ctx::CairoContext,value::AbstractString)
     ccall((:cairo_show_text, _jl_libcairo),
           Void, (Ptr{Void}, Ptr{UInt8}),
-          ctx.ptr, bytestring(value))
+          ctx.ptr, @compat(String(value)))
 end
 
 function text_path(ctx::CairoContext,value::AbstractString)
     ccall((:cairo_text_path, _jl_libcairo),
           Void, (Ptr{Void}, Ptr{UInt8}),
-          ctx.ptr, bytestring(value))
+          ctx.ptr, @compat(String(value)))
 end
 
 
@@ -944,7 +943,7 @@ function select_font_face(ctx::CairoContext,family::AbstractString,slant,weight)
     ccall((:cairo_select_font_face, _jl_libcairo),
           Void, (Ptr{Void}, Ptr{UInt8},
                  font_slant_t, font_weight_t),
-          ctx.ptr, bytestring(family),
+          ctx.ptr, @compat(String(family)),
           slant, weight)
 end
 
@@ -1000,7 +999,7 @@ type TeXLexer
     token_stack::Array{String,1}
 
     function TeXLexer(str::AbstractString)
-        s = bytestring(str)
+        s = @compat String(str)
         new(s, endof(s), 1, String[])
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Cairo
-using Compat
+using Compat, Colors
 using Base.Test: @test, @test_throws
 
 surf = CairoImageSurface(100, 200, Cairo.FORMAT_ARGB32)
@@ -8,6 +8,11 @@ surf = CairoImageSurface(100, 200, Cairo.FORMAT_ARGB32)
 ctx = CairoContext(surf)
 @test width(ctx) == 100
 @test height(ctx) == 200
+
+surf = CairoImageSurface(fill(RGB24(0), 10, 10))
+@test Cairo.format(surf) == RGB24
+surf = CairoImageSurface(fill(ARGB32(0), 10, 10))
+@test Cairo.format(surf) == ARGB32
 
 include("shape_functions.jl")
 include("test_stream.jl")
@@ -29,3 +34,4 @@ function test_pattern_get_surface()
 end
 
 test_pattern_get_surface()
+nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,4 +34,16 @@ function test_pattern_get_surface()
 end
 
 test_pattern_get_surface()
+
+# Run all the samples
+pth = joinpath(dirname(dirname(@__FILE__)), "samples")
+fls = filter(str->endswith(str,".jl"), readdir(pth))
+for fl in fls
+    include(joinpath(pth, fl))
+end
+pngfiles = filter(str->endswith(str,".png"), readdir())
+for fl in pngfiles
+    rm(fl)
+end
+
 nothing


### PR DESCRIPTION
This overdue change simply allows one to create a `CairoSurface` in terms of a `Matrix{T}` where  `T` is `RGB24` or `ARGB32` (from ColorTypes.jl). This allows Cairo to infer the (Cairo) format without having to mess with extra arguments.

Also fixes a number of deprecations on julia-0.5.