### PR TITLE
Support creating CairoContext and CairoSurface objects from Ptr{Void}

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -112,14 +112,18 @@ type CairoSurface{T<:@compat(Union{UInt32,RGB24,ARGB32})} <: GraphicsDevice
         self
     end
     function CairoSurface(ptr::Ptr{Void})
+        ccall(
+          (:cairo_surface_reference,_jl_libcairo),
+          Ptr{Void}, (Ptr{Void}, ), ptr)
         self = new(ptr)
-        #finalizer(self, destroy)
+        finalizer(self, destroy)
         self
     end
 end
 
 CairoSurface(ptr, w, h) = CairoSurface{UInt32}(ptr, w, h)
 CairoSurface{T}(ptr, w, h, data::Matrix{T}) = CairoSurface{T}(ptr, w, h, data)
+CairoSurface(ptr) = CairoSurface{UInt32}(ptr)
 
 width(surface::CairoSurface) = surface.width
 height(surface::CairoSurface) = surface.height
@@ -362,13 +366,15 @@ type CairoContext <: GraphicsContext
         self
     end
     function CairoContext(ptr::Ptr{Void})
+        ccall((:cairo_reference,_jl_libcairo),
+                   Ptr{Void}, (Ptr{Void},), ptr)
         surface_p = ccall((:cairo_get_target,_jl_libcairo),
                    Ptr{Void}, (Ptr{Void},), ptr)
         surface = CairoSurface(surface_p)
         layout = ccall((:pango_cairo_create_layout,_jl_libpangocairo),
                   Ptr{Void}, (Ptr{Void},), ptr)
         self = new(ptr,surface,layout)
-        #finalizer(self, destroy)
+        finalizer(self, destroy)
         self
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,4 +46,19 @@ for fl in pngfiles
     rm(fl)
 end
 
+# Test creating a CairoContext from a cairo_t pointer
+surf = CairoImageSurface(fill(ARGB32(0), 10, 10))
+ctx_ptr = ccall(
+    (:cairo_create, Cairo._jl_libcairo), 
+    Ptr{Void}, (Ptr{Void}, ), surf.ptr)
+ctx = CairoContext(ctx_ptr)
+@test isa(ctx, CairoContext)
+ccall(
+    (:cairo_destroy,Cairo._jl_libcairo),
+    Void, (Ptr{Void}, ), ctx_ptr)
+finalize(ctx)
+@test ccall(
+    (:cairo_get_reference_count,Cairo._jl_libcairo),
+    Cuint, (Ptr{Void},), ctx_ptr) == 0
+
 nothing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,13 +52,10 @@ ctx_ptr = ccall(
     (:cairo_create, Cairo._jl_libcairo), 
     Ptr{Void}, (Ptr{Void}, ), surf.ptr)
 ctx = CairoContext(ctx_ptr)
-@test isa(ctx, CairoContext)
 ccall(
     (:cairo_destroy,Cairo._jl_libcairo),
     Void, (Ptr{Void}, ), ctx_ptr)
-finalize(ctx)
-@test ccall(
-    (:cairo_get_reference_count,Cairo._jl_libcairo),
-    Cuint, (Ptr{Void},), ctx_ptr) == 0
+
+@test isa(ctx, CairoContext)
 
 nothing


### PR DESCRIPTION
This is an attempt at resolving issue #141.

* Primary piece for solving #141 is line 126 of the new Cairo.jl.
* When only the pointer is provided the reference count is incremented which prevents deletion but provides the behavior that appears to have been desired.
* A test is added so that future changes will cause a failed test if they break this functionality for `CairoContext` objects.