### PR TITLE
Convert a dimension to Int to fix a 32 bit error

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -622,7 +622,7 @@ function convert_cairo_path_data(p::CairoPath)
     # define here by Float64 (most data is) and reinterpret in the header.
 
     path_data = CairoPathEntry[]
-    c_data = @compat unsafe_wrap(Array,c.data,(c.num_data*2,1),true)
+    c_data = @compat unsafe_wrap(Array,c.data,(Int(c.num_data*2),1),true)
 
     data_index = 1
     while data_index <= ((c.num_data)*2)


### PR DESCRIPTION
see appveyor https://ci.appveyor.com/project/tkelman/cairo-jl/build/1.0.79/job/rni9sahayo0omppg

```
ERROR: LoadError: LoadError: MethodError: no method matching unsafe_wrap(::Type{Array}, ::Ptr{Float64}, ::Tuple{UInt32,Int32}, ::Bool)
Closest candidates are:
  unsafe_wrap{T,N}(::Union{Type{Array{T,N}},Type{Array{T,N}},Type{Array}}, ::Ptr{T}, ::Tuple{Vararg{Int32,N}}, ::Bool)
  unsafe_wrap{T}(::Union{Type{Array{T,1}},Type{Array{T,N}},Type{Array}}, ::Ptr{T}, ::Integer, ::Bool)
  unsafe_wrap{N,I<:Integer}(::Type{T}, ::Ptr{T}, ::Tuple{Vararg{I<:Integer,N}}, ::Bool)
  ...
 in convert_cairo_path_data(::Cairo.CairoPath) at C:\Users\Tony\.julia\v0.5\Cairo\src\Cairo.jl:625
 in example_copy_path(::Cairo.CairoContext) at C:\Users\Tony\.julia\v0.5\Cairo\samples\sample_copy_path.jl:40
 in include_from_node1 at .\loading.jl:426
 in macro expansion; at C:\Users\Tony\.julia\v0.5\Cairo\test\runtests.jl:47 [inlined]
```

Maybe `unsafe_wrap` should be smarter about unsigned dimensions? Not sure.

edit: also no idea why this might not be an issue on 64 bit, but something else is wrong on win64