### PR TITLE
copy path output should not be owned

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -622,7 +622,7 @@ function convert_cairo_path_data(p::CairoPath)
     # define here by Float64 (most data is) and reinterpret in the header.
 
     path_data = CairoPathEntry[]
-    c_data = @compat unsafe_wrap(Array,c.data,(Int(c.num_data*2),1),true)
+    c_data = @compat unsafe_wrap(Array,c.data,(Int(c.num_data*2),1),false)
 
     data_index = 1
     while data_index <= ((c.num_data)*2)


### PR DESCRIPTION
#146,#156 
the output pointer of copy path should not be owned by julia as libcairo (via glib) has own memory management.