### PR TITLE
add unexported vars storing pango/cairo version literals

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -13,6 +13,19 @@ using Colors
 importall Graphics
 import Base: copy
 
+libcairo_version = VersionNumber(unsafe_string(
+      ccall((:cairo_version_string,Cairo._jl_libcairo),Cstring,()) ))
+libpango_version = VersionNumber(unsafe_string(
+      ccall((:pango_version_string,Cairo._jl_libpango),Cstring,()) ))
+if !is_windows()
+    libpangocairo_version = VersionNumber(unsafe_string(
+          ccall((:pango_version_string,Cairo._jl_libpangocairo),Cstring,()) ))
+    libgobject_version = VersionNumber( 
+          unsafe_load(cglobal((:glib_major_version, Cairo._jl_libgobject), Cuint)),
+          unsafe_load(cglobal((:glib_minor_version, Cairo._jl_libgobject), Cuint)),
+          unsafe_load(cglobal((:glib_micro_version, Cairo._jl_libgobject), Cuint)))
+end
+
 @compat import Base.show
 
 include("constants.jl")

--- a/test/test_speed.jl
+++ b/test/test_speed.jl
@@ -2,7 +2,7 @@ using Cairo
 include("shape_functions.jl")
 
 function test_all(;tmax = 2.0, save_flag = false)
-    print("cairo version: ",ccall((:cairo_version,Cairo._jl_libcairo),Int32,()),"\n");
+    print("cairo version: ",Cairo.libcairo_version,"\n");
     size_surface = [512];#,512,1024]; #three sizes of a surface
     paint_width = [0.5,1.0,3.0,5.0];
     shapes = [ddots1, ddots2, ddots3, ddots4, ddots5,


### PR DESCRIPTION
i would add similar for gobject and pangocairo but there doesn't seem to be a way to query their version at runtime.