### PR TITLE
Remove deprecated Array(T,dims) syntax

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -651,7 +651,7 @@ function convert_cairo_path_data(p::CairoPath)
         element_type = reinterpret(UInt64,c_data[data_index]) & 0xffffffff
 
         # copy points x,y
-        points = Array(Float64,(element_length-1)*2)
+        points = Vector{Float64}((element_length - 1) * 2)
         for i=1:(element_length-1)*2
             points[i] = c_data[data_index+i+1]
         end
@@ -904,7 +904,7 @@ function set_text(ctx::CairoContext, text::AbstractString, markup::Bool = false)
 end
 
 function get_layout_size(ctx::CairoContext)
-    w = Array(Int32,2)
+    w = Vector{Int32}(2)
     ccall((:pango_layout_get_pixel_size,_jl_libpango), Void,
           (Ptr{Void},Ptr{Int32},Ptr{Int32}), ctx.layout, pointer(w,1), pointer(w,2))
     w
@@ -920,7 +920,7 @@ function show_layout(ctx::CairoContext)
           (Ptr{Void},Ptr{Void}), ctx.ptr, ctx.layout)
 end
 
-text_extents(ctx::CairoContext,value::AbstractString) = text_extents!(ctx,value,Array(Float64, 6, 1))
+text_extents(ctx::CairoContext,value::AbstractString) = text_extents!(ctx,value, Matrix{Float64}(6, 1))
 
 function text_extents!(ctx::CairoContext,value::AbstractString,extents)
     ccall((:cairo_text_extents, _jl_libcairo),


### PR DESCRIPTION
Change Array statements to `Vector/Matrix` equivalents, using `(Array{T}(dims)` form. Currently the deprecation warnings are making the Travis logs too long to display (the last one was 429,255 lines) :)