### PR TITLE
Quote shell wildcards in the build process

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -149,9 +149,9 @@ provides(BuildProcess,
             FileRule(joinpath(prefix,"lib","libpng15.dll"),@build_steps begin
                 `cmake -DCMAKE_INSTALL_PREFIX="$prefix" -G"MSYS Makefiles" $pngsrcdir`
                 `make`
-                `cp libpng*.dll $prefix/lib`
-                `cp libpng*.a $prefix/lib`
-                `cp libpng*.pc $prefix/lib/pkgconfig`
+                `cp 'libpng*.dll' $prefix/lib`
+                `cp 'libpng*.a' $prefix/lib`
+                `cp 'libpng*.pc' $prefix/lib/pkgconfig`
                 `cp pnglibconf.h $prefix/include`
                 `cp $pngsrcdir/png.h $prefix/include`
                 `cp $pngsrcdir/pngconf.h $prefix/include`


### PR DESCRIPTION
Avoids deprecation warnings on Julia 0.6.

I tried to do the inner constructor syntax too but I only have access to the GitHub web UI at the moment and it kept crashing whenever I tried to make that change. 😕 