### PR TITLE
Update type constructor syntax

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -132,12 +132,12 @@ type CairoSurface{T<:Union{UInt32,RGB24,ARGB32}} <: GraphicsDevice
     data::Matrix{T}
 
     @compat function (::Type{CairoSurface{T}}){T}(ptr::Ptr{Void}, w, h)
-        self = new(ptr, w, h)
+        self = new{T}(ptr, w, h)
         finalizer(self, destroy)
         self
     end
     @compat function (::Type{CairoSurface{T}}){T}(ptr::Ptr{Void}, w, h, data::Matrix{T})
-        self = new(ptr, w, h, data)
+        self = new{T}(ptr, w, h, data)
         finalizer(self, destroy)
         self
     end
@@ -145,7 +145,7 @@ type CairoSurface{T<:Union{UInt32,RGB24,ARGB32}} <: GraphicsDevice
         ccall(
           (:cairo_surface_reference,_jl_libcairo),
           Ptr{Void}, (Ptr{Void}, ), ptr)
-        self = new(ptr)
+        self = new{T}(ptr)
         finalizer(self, destroy)
         self
     end

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -151,9 +151,9 @@ type CairoSurface{T<:Union{UInt32,RGB24,ARGB32}} <: GraphicsDevice
     end
 end
 
-@compat (::Type{CairoSurface{T}})(ptr, w, h) = CairoSurface{UInt32}(ptr, w, h)
-@compat (::Type{CairoSurface{T}})(ptr, w, h, data) = CairoSurface{eltype(data)}(ptr, w, h, data)
-@compat (::Type{CairoSurface{T}})(ptr) = CairoSurface{UInt32}(ptr)
+@compat (::Type{CairoSurface})(ptr, w, h) = CairoSurface{UInt32}(ptr, w, h)
+@compat (::Type{CairoSurface})(ptr, w, h, data) = CairoSurface{eltype(data)}(ptr, w, h, data)
+@compat (::Type{CairoSurface})(ptr) = CairoSurface{UInt32}(ptr)
 
 width(surface::CairoSurface) = surface.width
 height(surface::CairoSurface) = surface.height

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -125,23 +125,23 @@ end
 get_readstream_callback(T) = cfunction(read_from_stream_callback, Int32, (Ref{T}, Ptr{UInt8}, UInt32))
 
 
-type CairoSurface{T<:@compat(Union{UInt32,RGB24,ARGB32})} <: GraphicsDevice
+type CairoSurface{T<:Union{UInt32,RGB24,ARGB32}} <: GraphicsDevice
     ptr::Ptr{Void}
     width::Float64
     height::Float64
     data::Matrix{T}
 
-    function CairoSurface(ptr::Ptr{Void}, w, h)
+    @compat function (::Type{CairoSurface{T}}){T}(ptr::Ptr{Void}, w, h)
         self = new(ptr, w, h)
         finalizer(self, destroy)
         self
     end
-    function CairoSurface(ptr::Ptr{Void}, w, h, data)
+    @compat function (::Type{CairoSurface{T}}){T}(ptr::Ptr{Void}, w, h, data::Matrix{T})
         self = new(ptr, w, h, data)
         finalizer(self, destroy)
         self
     end
-    function CairoSurface(ptr::Ptr{Void})
+    @compat function (::Type{CairoSurface{T}}){T}(ptr::Ptr{Void})
         ccall(
           (:cairo_surface_reference,_jl_libcairo),
           Ptr{Void}, (Ptr{Void}, ), ptr)
@@ -151,9 +151,9 @@ type CairoSurface{T<:@compat(Union{UInt32,RGB24,ARGB32})} <: GraphicsDevice
     end
 end
 
-CairoSurface(ptr, w, h) = CairoSurface{UInt32}(ptr, w, h)
-CairoSurface{T}(ptr, w, h, data::Matrix{T}) = CairoSurface{T}(ptr, w, h, data)
-CairoSurface(ptr) = CairoSurface{UInt32}(ptr)
+@compat (::Type{CairoSurface{T}})(ptr, w, h) = CairoSurface{UInt32}(ptr, w, h)
+@compat (::Type{CairoSurface{T}})(ptr, w, h, data) = CairoSurface{eltype(data)}(ptr, w, h, data)
+@compat (::Type{CairoSurface{T}})(ptr) = CairoSurface{UInt32}(ptr)
 
 width(surface::CairoSurface) = surface.width
 height(surface::CairoSurface) = surface.height


### PR DESCRIPTION
This PR updates the deprecated type constructor syntax used for `CairoSurface` to the 0.4-0.6 compatible syntax. (Note that `@compat` is required for 0.4.)

Fixes the last remaining item in #176.