### PR TITLE
Updates for Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,27 @@
 matrix:
     include:
        - language: julia
-         julia: 0.5
+         julia: 0.6
          os: linux
          dist: trusty
-         sudo: false         
+         sudo: false
        - language: julia
-         julia: 0.6 
+         julia: master
          os: linux
          dist: trusty
-         sudo: false         
+         sudo: false
        - language: julia
-         julia: 0.5
+         julia: 0.6
          os: linux
        - language: julia
-         julia: 0.5
+         julia: master
+         os: linux
+
+       - language: julia
+         julia: 0.6
          os: osx
        - language: julia
-         julia: 0.6 
+         julia: master
          os: osx
 notifications:
     email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 Compat 0.39.0
 Colors
 BinDeps 0.3.21

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -59,7 +59,7 @@ end
 
 # System Package Managers
 provides(AptGet,
-    @compat Dict(
+    Dict(
         "libcairo2" => cairo,
         "libfontconfig1" => fontconfig,
         "libpango1.0-0" => [pango,pangocairo],
@@ -71,7 +71,7 @@ provides(AptGet,
 
 # TODO: check whether these are accurate
 provides(Yum,
-    @compat Dict(
+    Dict(
         "cairo" => cairo,
         "fontconfig" => fontconfig,
         "pango" => [pango,pangocairo],
@@ -81,7 +81,7 @@ provides(Yum,
     ))
     
 provides(Zypper,
-    @compat Dict(
+    Dict(
         "libcairo" => cairo,
         "libfontconfig" => fontconfig,
         "libpango-1.0" => [pango,pangocairo],
@@ -94,7 +94,7 @@ provides(Zypper,
 const png_version = "1.5.14"
 
 provides(Sources,
-    @compat Dict(
+    Dict(
         URI("http://www.cairographics.org/releases/pixman-0.28.2.tar.gz") => pixman,
         URI("http://www.cairographics.org/releases/cairo-1.12.16.tar.xz") => cairo,
         URI("http://download.savannah.gnu.org/releases/freetype/freetype-2.4.11.tar.gz") => freetype,
@@ -110,7 +110,7 @@ provides(Sources,
 xx(t...) = (is_windows() ? t[1] : (is_linux() || length(t) == 2) ? t[2] : t[3])
 
 provides(BuildProcess,
-    @compat Dict(
+    Dict(
         Autotools(libtarget = "pixman/libpixman-1.la", installed_libname = xx("libpixman-1-0.","libpixman-1.","libpixman-1.0.")*Libdl.dlext) => pixman,
         Autotools(libtarget = xx("objs/.libs/libfreetype.la","libfreetype.la")) => freetype,
         Autotools(libtarget = "src/libfontconfig.la") => fontconfig,

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,14 +1,19 @@
 using BinDeps
 
+using Compat
+import Compat.Libdl
+import Compat.Sys
+using Pkg
+
 @BinDeps.setup
 
 using Compat
 
-# check for cairo version 
+# check for cairo version
 function validate_cairo_version(name,handle)
     f = Libdl.dlsym_e(handle, "cairo_version")
     f == C_NULL && return false
-    v = ccall(f, Int32,())        
+    v = ccall(f, Int32,())
     return v > 10800
 end
 
@@ -28,7 +33,7 @@ deps = [
     zlib = library_dependency("zlib", aliases = ["libzlib","zlib1"], os = :Windows, group = group)
 ]
 
-if is_windows()
+if Sys.iswindows()
     using WinRPM
     provides(WinRPM.RPM,"libpango-1_0-0",[pango,pangocairo],os = :Windows)
     provides(WinRPM.RPM,["glib2", "libgobject-2_0-0"],gobject,os = :Windows)
@@ -79,7 +84,7 @@ provides(Yum,
         "libpng" => libpng,
         "gettext-libs" => gettext
     ))
-    
+
 provides(Zypper,
     Dict(
         "libcairo" => cairo,
@@ -107,7 +112,7 @@ provides(Sources,
         URI("http://zlib.net/zlib-1.2.7.tar.gz") => zlib
     ))
 
-xx(t...) = (is_windows() ? t[1] : (is_linux() || length(t) == 2) ? t[2] : t[3])
+xx(t...) = (Sys.iswindows() ? t[1] : (is_linux() || length(t) == 2) ? t[2] : t[3])
 
 provides(BuildProcess,
     Dict(

--- a/samples/sample_alpha_paint.jl
+++ b/samples/sample_alpha_paint.jl
@@ -1,13 +1,14 @@
 ## header to provide surface and context
 using Cairo
 using Colors
+using Compat
 
-c = CairoRGBSurface(256,256);
-cr = CairoContext(c);
+c = CairoRGBSurface(256,256)
+cr = CairoContext(c)
 
-save(cr);
+save(cr)
 
-z = Array{RGB24}(2,2)
+z = Array{RGB24}(uninitialized, 2, 2)
 c1 = convert(RGB24,colorant"grey20")
 c2 = convert(RGB24,colorant"grey80")
 z[1,1] = c1
@@ -16,18 +17,18 @@ z[2,1] = c2
 z[2,2] = c1
 
 img = CairoImageSurface(z)
-pattern = CairoPattern(img);
-pattern_set_extend(pattern, Cairo.EXTEND_REPEAT);
-pattern_set_filter(pattern, Cairo.FILTER_BILINEAR);
+pattern = CairoPattern(img)
+pattern_set_extend(pattern, Cairo.EXTEND_REPEAT)
+pattern_set_filter(pattern, Cairo.FILTER_BILINEAR)
 
-m = CairoMatrix(1/8.0,0,0,1/8.0,0,0);
+m = CairoMatrix(1/8.0,0,0,1/8.0,0,0)
 
-set_matrix(pattern, m);
-set_source(cr, pattern);
-paint(cr);
-restore(cr);
+set_matrix(pattern, m)
+set_source(cr, pattern)
+paint(cr)
+restore(cr)
 
-save(cr);
+save(cr)
 
 # 5 uses of set_source
 
@@ -75,8 +76,8 @@ restore(cr)
 
 
 ## mark picture with current date
-restore(cr);
-move_to(cr,0.0,12.0);
-set_source_rgb(cr, 0,0,0);
-show_text(cr,Libc.strftime(time()));
-write_to_png(c,"sample_alpha_paint.png");
+restore(cr)
+move_to(cr,0.0,12.0)
+set_source_rgb(cr, 0,0,0)
+show_text(cr,Libc.strftime(time()))
+write_to_png(c,"sample_alpha_paint.png")

--- a/samples/sample_arc.jl
+++ b/samples/sample_arc.jl
@@ -1,5 +1,6 @@
 ## header to provide surface and context
 using Cairo
+
 c = CairoRGBSurface(256,256);
 cr = CairoContext(c);
 
@@ -13,14 +14,14 @@ restore(cr);
 xc = 128.0;
 yc = 128.0;
 radius = 100.0;
-angle1 = 45.0  * (pi/180.0);  # angles are specified 
-angle2 = 180.0 * (pi/180.0);  # in radians           
+angle1 = 45.0  * (pi/180.0);  # angles are specified
+angle2 = 180.0 * (pi/180.0);  # in radians
 
 set_line_width(cr, 10.0);
 arc(cr, xc, yc, radius, angle1, angle2);
 stroke(cr);
 
-# draw helping lines 
+# draw helping lines
 set_source_rgba(cr, 1, 0.2, 0.2, 0.6);
 set_line_width(cr, 6.0);
 

--- a/samples/sample_arc_negative.jl
+++ b/samples/sample_arc_negative.jl
@@ -13,14 +13,14 @@ restore(cr);
 xc = 128.0;
 yc = 128.0;
 radius = 100.0;
-angle1 = 45.0  * (pi/180.0);  # angles are specified 
-angle2 = 180.0 * (pi/180.0);  # in radians           
+angle1 = 45.0  * (pi/180.0);  # angles are specified
+angle2 = 180.0 * (pi/180.0);  # in radians
 
 set_line_width(cr, 10.0);
 arc_negative(cr, xc, yc, radius, angle1, angle2);
 stroke(cr);
 
-# draw helping lines 
+# draw helping lines
 set_source_rgba(cr, 1, 0.2, 0.2, 0.6);
 set_line_width(cr, 6.0);
 

--- a/samples/sample_copy_path.jl
+++ b/samples/sample_copy_path.jl
@@ -57,7 +57,7 @@ function example_copy_path(cr)
         s1 = repr(x.points)
         move_to(cr,100.0,14.0*l)
         l += 1
-        show_text(cr,s0*s1); # 
+        show_text(cr,s0*s1)
     end
     nothing
 end

--- a/samples/sample_copy_path_flat.jl
+++ b/samples/sample_copy_path_flat.jl
@@ -1,28 +1,29 @@
 ## header to provide surface and context
 using Cairo
-c = CairoRGBSurface(256,256);
-cr = CairoContext(c);
 
-save(cr);
-set_source_rgb(cr,0.8,0.8,0.8);    # light gray
-rectangle(cr,0.0,0.0,256.0,256.0); # background
-fill(cr);
-restore(cr);
+c = CairoRGBSurface(256,256)
+cr = CairoContext(c)
 
-save(cr);
+save(cr)
+set_source_rgb(cr,0.8,0.8,0.8)    # light gray
+rectangle(cr,0.0,0.0,256.0,256.0) # background
+fill(cr)
+restore(cr)
+
+save(cr)
 
 ## original example, following here
-move_to(cr, 16.0, 32.0);
-curve_to(cr, 16.0, 16.0, 16.0, 16.0, 32.0, 16.0);
+move_to(cr, 16.0, 32.0)
+curve_to(cr, 16.0, 16.0, 16.0, 16.0, 32.0, 16.0)
 
-opath = Cairo.convert_cairo_path_data(Cairo.copy_path(cr));
-dx,dy,ex,ey = path_extents(cr);
+opath = Cairo.convert_cairo_path_data(Cairo.copy_path(cr))
+dx,dy,ex,ey = path_extents(cr)
 
-fpath = Cairo.convert_cairo_path_data(Cairo.copy_path_flat(cr));
+fpath = Cairo.convert_cairo_path_data(Cairo.copy_path_flat(cr))
 
-stroke(cr);
+stroke(cr)
 
-restore(cr);
+restore(cr)
 
 l = 2 # something like a line counter
 
@@ -40,7 +41,7 @@ for x in opath
     s1 = repr(x.points)
     move_to(cr,10.0,16.0+(14.0*l))
     l += 1
-    show_text(cr,s0*s1); # 
+    show_text(cr,s0*s1)
 end
 
 l = 2 # something like a line counter
@@ -59,15 +60,15 @@ for x in fpath
     s1 = repr(x.points)
     move_to(cr,10.0,50.0+(14.0*l))
     l += 1
-    show_text(cr,s0*s1); # 
+    show_text(cr,s0*s1)
 end
 
 
 ## mark picture with current date
-restore(cr);
+restore(cr)
 
-move_to(cr,0.0,12.0);
-set_source_rgb(cr, 0,0,0);
-show_text(cr,Libc.strftime(time()));
+move_to(cr,0.0,12.0)
+set_source_rgb(cr, 0,0,0)
+show_text(cr,Libc.strftime(time()))
 
-write_to_png(c,"sample_copy_path_flat.png");
+write_to_png(c,"sample_copy_path_flat.png")

--- a/samples/sample_pango_text.jl
+++ b/samples/sample_pango_text.jl
@@ -1,5 +1,5 @@
 ## header to provide surface and context
-using Cairo
+using Cairo, Compat, Printf
 c = CairoRGBSurface(256,256);
 cr = CairoContext(c);
 
@@ -19,7 +19,7 @@ text(cr,16.0,104.0,"Text<b>Bold</b><i>Italic</i><sup>super-2</sup>",markup=true)
 
 text(cr,40.0,224.0,"Es geht <span foreground=\"white\" background=\"blue\">aufwärts</span> !",markup=true,angle=30.0)
 
-#using textwidth and height 
+#using textwidth and height
 
 set_font_face(cr, "Sans 12")
 

--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -2,8 +2,8 @@ __precompile__()
 
 module Cairo
 
-using Compat; import Compat: String, textwidth
-
+using Compat
+import Compat.Sys
 
 depsjl = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 isfile(depsjl) ? include(depsjl) : error("Cairo not properly ",
@@ -11,14 +11,16 @@ isfile(depsjl) ? include(depsjl) : error("Cairo not properly ",
 
 using Colors
 
-importall Graphics
-import Base: copy
+import Graphics
+using Graphics: BoundingBox, GraphicsContext, GraphicsDevice
+import Graphics: arc, clip, close_path, creategc, fill_preserve, height, line_to, move_to, new_path, new_sub_path, paint, rectangle, rel_line_to, reset_clip, restore, rotate, save, scale, set_dash, set_line_width, set_source, set_source_rgb, set_source_rgba, stroke, stroke_preserve, textwidth, translate, width
+import Base: copy, fill
 
 libcairo_version = VersionNumber(unsafe_string(
       ccall((:cairo_version_string,Cairo._jl_libcairo),Cstring,()) ))
 libpango_version = VersionNumber(unsafe_string(
       ccall((:pango_version_string,Cairo._jl_libpango),Cstring,()) ))
-if !is_windows()
+if !Sys.iswindows()
     libpangocairo_version = VersionNumber(unsafe_string(
           ccall((:pango_version_string,Cairo._jl_libpangocairo),Cstring,()) ))
     libgobject_version = VersionNumber(
@@ -43,7 +45,7 @@ export
 
     # surface and context management
     finish, destroy, status, get_source,
-    creategc, getgc, save, restore, show_page, width, height,
+    creategc, save, restore, show_page, width, height,
 
     # pattern
     pattern_create_radial, pattern_create_linear,
@@ -113,7 +115,7 @@ Surfaces, the canvas you are painting on
 Context, the handle to coordinate transformation, paint+Color
 
     CairoContext, finish, destroy, status, get_source,
-    creategc, getgc, save, restore, show_page, width, height
+    creategc, save, restore, show_page, width, height
 
 Path creation API
 
@@ -130,7 +132,7 @@ Stroking and painting API
     stroke_preserve, stroke_transformed, stroke_transformed_preserve
 
     CairoContext, finish, destroy, status, get_source,
-    creategc, getgc, save, restore, show_page, width, height
+    creategc, save, restore, show_page, width, height
 
 "
 Cairo
@@ -140,7 +142,7 @@ function write_to_stream_callback(s::IO, buf::Ptr{UInt8}, len::UInt32)
     Int32((n == len) ? 0 : 11)
 end
 
-get_stream_callback(T) = cfunction(write_to_stream_callback, Int32, (Ref{T}, Ptr{UInt8}, UInt32))
+get_stream_callback(T) = cfunction(write_to_stream_callback, Int32, Tuple{Ref{T}, Ptr{UInt8}, UInt32})
 
 
 function read_from_stream_callback(s::IO, buf::Ptr{UInt8}, len::UInt32)
@@ -154,31 +156,31 @@ function read_from_stream_callback(s::IO, buf::Ptr{UInt8}, len::UInt32)
     (nb == len) ? STATUS_SUCCESS : STATUS_READ_ERROR
 end
 
-get_readstream_callback(T) = cfunction(read_from_stream_callback, Int32, (Ref{T}, Ptr{UInt8}, UInt32))
+get_readstream_callback(T) = cfunction(read_from_stream_callback, Int32, Tuple{Ref{T}, Ptr{UInt8}, UInt32})
 
 
-type CairoSurface{T<:Union{UInt32,RGB24,ARGB32}} <: GraphicsDevice
-    ptr::Ptr{Void}
+mutable struct CairoSurface{T<:Union{UInt32,RGB24,ARGB32}} <: GraphicsDevice
+    ptr::Ptr{Nothing}
     width::Float64
     height::Float64
     data::Matrix{T}
 
-    @compat function (::Type{CairoSurface{T}}){T}(ptr::Ptr{Void}, w, h)
+    function (::Type{CairoSurface{T}})(ptr::Ptr{Nothing}, w, h) where {T}
         self = new{T}(ptr, w, h)
-        finalizer(destroy, self)
+        @compat finalizer(destroy, self)
         self
     end
-    @compat function (::Type{CairoSurface{T}}){T}(ptr::Ptr{Void}, w, h, data::Matrix{T})
+    function (::Type{CairoSurface{T}})(ptr::Ptr{Nothing}, w, h, data::Matrix{T}) where {T}
         self = new{T}(ptr, w, h, data)
-        finalizer(destroy, self)
+        @compat finalizer(destroy, self)
         self
     end
-    @compat function (::Type{CairoSurface{T}}){T}(ptr::Ptr{Void})
+    function (::Type{CairoSurface{T}})(ptr::Ptr{Nothing}) where {T}
         ccall(
           (:cairo_surface_reference,_jl_libcairo),
-          Ptr{Void}, (Ptr{Void}, ), ptr)
+          Ptr{Nothing}, (Ptr{Nothing}, ), ptr)
         self = new{T}(ptr)
-        finalizer(destroy, self)
+        @compat finalizer(destroy, self)
         self
     end
 end
@@ -194,7 +196,7 @@ function destroy(surface::CairoSurface)
     if surface.ptr == C_NULL
         return
     end
-    ccall((:cairo_surface_destroy,_jl_libcairo), Void, (Ptr{Void},), surface.ptr)
+    ccall((:cairo_surface_destroy,_jl_libcairo), Nothing, (Ptr{Nothing},), surface.ptr)
     surface.ptr = C_NULL
     nothing
 end
@@ -215,18 +217,18 @@ for name in (:finish,:flush,:mark_dirty)
     @eval begin
         $name(surface::CairoSurface) =
             ccall(($(string("cairo_surface_",name)),_jl_libcairo),
-                  Void, (Ptr{Void},), surface.ptr)
+                  Nothing, (Ptr{Nothing},), surface.ptr)
     end
 end
 
 function status(surface::CairoSurface)
     ccall((:cairo_surface_status,_jl_libcairo),
-          Int32, (Ptr{Void},), surface.ptr)
+          Int32, (Ptr{Nothing},), surface.ptr)
 end
 
 function CairoImageSurface(w::Real, h::Real, format::Integer)
     ptr = ccall((:cairo_image_surface_create,_jl_libcairo),
-                Ptr{Void}, (Int32,Int32,Int32), format, w, h)
+                Ptr{Nothing}, (Int32,Int32,Int32), format, w, h)
     CairoSurface(ptr, w, h)
 end
 
@@ -237,111 +239,111 @@ CairoRGBSurface(img) = CairoImageSurface(img, FORMAT_RGB24)
 
 function CairoImageSurface(img::Array{UInt32,2}, format::Integer; flipxy::Bool = true)
     if flipxy
-        img = img'
+        img = permutedims(img, (2,1))
     end
     w,h = size(img)
     stride = format_stride_for_width(format, w)
     @assert stride == 4w
     ptr = ccall((:cairo_image_surface_create_for_data,_jl_libcairo),
-                Ptr{Void}, (Ptr{Void},Int32,Int32,Int32,Int32),
+                Ptr{Nothing}, (Ptr{Nothing},Int32,Int32,Int32,Int32),
                 img, format, w, h, stride)
     CairoSurface(ptr, w, h, img)
 end
 
-function CairoImageSurface{T<:Union{RGB24,ARGB32}}(img::Matrix{T})
+function CairoImageSurface(img::Matrix{T}) where {T<:Union{RGB24,ARGB32}}
     w,h = size(img)
     stride = format_stride_for_width(format(T), w)
     @assert stride == 4w
     ptr = ccall((:cairo_image_surface_create_for_data,_jl_libcairo),
-                Ptr{Void}, (Ptr{Void},Int32,Int32,Int32,Int32),
+                Ptr{Nothing}, (Ptr{Nothing},Int32,Int32,Int32,Int32),
                 img, format(T), w, h, stride)
     CairoSurface(ptr, w, h, img)
 end
 
 format(::Type{RGB24}) = FORMAT_RGB24
 format(::Type{ARGB32}) = FORMAT_ARGB32
-format{T<:Union{RGB24,ARGB32}}(surf::CairoSurface{T}) = T
+format(surf::CairoSurface{T}) where {T<:Union{RGB24,ARGB32}} = T
 
 ## PDF ##
 
-function CairoPDFSurface{T<:IO}(stream::T, w::Real, h::Real)
+function CairoPDFSurface(stream::T, w::Real, h::Real) where {T<:IO}
     callback = get_stream_callback(T)
-    ptr = ccall((:cairo_pdf_surface_create_for_stream,_jl_libcairo), Ptr{Void},
-                (Ptr{Void}, Any, Float64, Float64), callback, stream, w, h)
+    ptr = ccall((:cairo_pdf_surface_create_for_stream,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing}, Any, Float64, Float64), callback, stream, w, h)
     CairoSurface(ptr, w, h)
 end
 
 function CairoPDFSurface(filename::AbstractString, w_pts::Real, h_pts::Real)
-    ptr = ccall((:cairo_pdf_surface_create,_jl_libcairo), Ptr{Void},
+    ptr = ccall((:cairo_pdf_surface_create,_jl_libcairo), Ptr{Nothing},
                 (Ptr{UInt8},Float64,Float64), String(filename), w_pts, h_pts)
     CairoSurface(ptr, w_pts, h_pts)
 end
 
 ## EPS ##
 
-function CairoEPSSurface{T<:IO}(stream::T, w::Real, h::Real)
+function CairoEPSSurface(stream::T, w::Real, h::Real) where {T<:IO}
     callback = get_stream_callback(T)
-    ptr = ccall((:cairo_ps_surface_create_for_stream,_jl_libcairo), Ptr{Void},
-                (Ptr{Void}, Any, Float64, Float64), callback, stream, w, h)
-    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Void,
-        (Ptr{Void},Int32), ptr, 1)
+    ptr = ccall((:cairo_ps_surface_create_for_stream,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing}, Any, Float64, Float64), callback, stream, w, h)
+    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Nothing,
+        (Ptr{Nothing},Int32), ptr, 1)
     CairoSurface(ptr, w, h)
 end
 
 function CairoEPSSurface(filename::AbstractString, w_pts::Real, h_pts::Real)
-    ptr = ccall((:cairo_ps_surface_create,_jl_libcairo), Ptr{Void},
+    ptr = ccall((:cairo_ps_surface_create,_jl_libcairo), Ptr{Nothing},
                 (Ptr{UInt8},Float64,Float64), String(filename), w_pts, h_pts)
-    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Void,
-          (Ptr{Void},Int32), ptr, 1)
+    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Nothing,
+          (Ptr{Nothing},Int32), ptr, 1)
     CairoSurface(ptr, w_pts, h_pts)
 end
 
 ## PS ##
 
 function CairoPSSurface(stream::IOStream, w::Real, h::Real)
-    callback = cfunction(write_to_ios_callback, Int32, (Ptr{Void},Ptr{UInt8},UInt32))
-    ptr = ccall((:cairo_ps_surface_create_for_stream,_jl_libcairo), Ptr{Void},
-                (Ptr{Void}, Ptr{Void}, Float64, Float64), callback, stream, w, h)
-    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Void,
-        (Ptr{Void},Int32), ptr, 0)
+    callback = cfunction(write_to_ios_callback, Int32, Tuple{Ptr{Nothing},Ptr{UInt8},UInt32})
+    ptr = ccall((:cairo_ps_surface_create_for_stream,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing}, Ptr{Nothing}, Float64, Float64), callback, stream, w, h)
+    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Nothing,
+        (Ptr{Nothing},Int32), ptr, 0)
     CairoSurface(ptr, w, h)
 end
 
-function CairoPSSurface{T<:IO}(stream::T, w::Real, h::Real)
+function CairoPSSurface(stream::T, w::Real, h::Real) where {T<:IO}
     callback = get_stream_callback(T)
-    ptr = ccall((:cairo_ps_surface_create_for_stream,_jl_libcairo), Ptr{Void},
-                (Ptr{Void}, Any, Float64, Float64), callback, stream, w, h)
-    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Void,
-        (Ptr{Void},Int32), ptr, 0)
+    ptr = ccall((:cairo_ps_surface_create_for_stream,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing}, Any, Float64, Float64), callback, stream, w, h)
+    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Nothing,
+        (Ptr{Nothing},Int32), ptr, 0)
     CairoSurface(ptr, w, h)
 end
 
 function CairoPSSurface(filename::AbstractString, w_pts::Real, h_pts::Real)
-    ptr = ccall((:cairo_ps_surface_create,_jl_libcairo), Ptr{Void},
+    ptr = ccall((:cairo_ps_surface_create,_jl_libcairo), Ptr{Nothing},
                 (Ptr{UInt8},Float64,Float64), String(filename), w_pts, h_pts)
-    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Void,
-          (Ptr{Void},Int32), ptr, 0)
+    ccall((:cairo_ps_surface_set_eps,_jl_libcairo), Nothing,
+          (Ptr{Nothing},Int32), ptr, 0)
     CairoSurface(ptr, w_pts, h_pts)
 end
 
 ## Xlib ##
 
 function CairoXlibSurface(display, drawable, visual, w, h)
-    ptr = ccall((:cairo_xlib_surface_create,_jl_libcairo), Ptr{Void},
-                (Ptr{Void}, Int, Ptr{Void}, Int32, Int32),
+    ptr = ccall((:cairo_xlib_surface_create,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing}, Int, Ptr{Nothing}, Int32, Int32),
                 display, drawable, visual, w, h)
     CairoSurface(ptr, w, h)
 end
 
 CairoXlibSurfaceSetSize(surface, w, h) =
-    ccall((:cairo_xlib_surface_set_size,_jl_libcairo), Void,
-          (Ptr{Void}, Int32, Int32),
+    ccall((:cairo_xlib_surface_set_size,_jl_libcairo), Nothing,
+          (Ptr{Nothing}, Int32, Int32),
           surface, w, h)
 
 ## Quartz ##
 function CairoQuartzSurface(context, w, h)
     ptr = ccall((:cairo_quartz_surface_create_for_cg_context,_jl_libcairo),
-          Ptr{Void}, (Ptr{Void}, UInt32, UInt32), context, w, h)
+          Ptr{Nothing}, (Ptr{Nothing}, UInt32, UInt32), context, w, h)
     CairoSurface(ptr, w, h)
 end
 
@@ -349,21 +351,21 @@ end
 
 function CairoWin32Surface(hdc,w,h)
     ptr = ccall((:cairo_win32_surface_create, _jl_libcairo),
-                Ptr{Void}, (Ptr{Void},), hdc)
+                Ptr{Nothing}, (Ptr{Nothing},), hdc)
     CairoSurface(ptr,w,h)
 end
 
 ## SVG ##
 
-function CairoSVGSurface{T<:IO}(stream::T, w::Real, h::Real)
+function CairoSVGSurface(stream::T, w::Real, h::Real) where {T<:IO}
     callback = get_stream_callback(T)
-    ptr = ccall((:cairo_svg_surface_create_for_stream,_jl_libcairo), Ptr{Void},
-                (Ptr{Void}, Any, Float64, Float64), callback, stream, w, h)
+    ptr = ccall((:cairo_svg_surface_create_for_stream,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing}, Any, Float64, Float64), callback, stream, w, h)
     CairoSurface(ptr, w, h)
 end
 
 function CairoSVGSurface(filename::AbstractString, w::Real, h::Real)
-    ptr = ccall((:cairo_svg_surface_create,_jl_libcairo), Ptr{Void},
+    ptr = ccall((:cairo_svg_surface_create,_jl_libcairo), Ptr{Nothing},
                 (Ptr{UInt8},Float64,Float64), String(filename), w, h)
     CairoSurface(ptr, w, h)
 end
@@ -372,36 +374,36 @@ end
 
 function read_from_png(filename::AbstractString)
     ptr = ccall((:cairo_image_surface_create_from_png,_jl_libcairo),
-                Ptr{Void}, (Ptr{UInt8},), String(filename))
+                Ptr{Nothing}, (Ptr{UInt8},), String(filename))
     w = ccall((:cairo_image_surface_get_width,_jl_libcairo),
-              Int32, (Ptr{Void},), ptr)
+              Int32, (Ptr{Nothing},), ptr)
     h = ccall((:cairo_image_surface_get_height,_jl_libcairo),
-              Int32, (Ptr{Void},), ptr)
+              Int32, (Ptr{Nothing},), ptr)
     CairoSurface(ptr, w, h)
 end
 
-function write_to_png{T<:IO}(surface::CairoSurface, stream::T)
+function write_to_png(surface::CairoSurface, stream::T) where {T<:IO}
     callback = get_stream_callback(T)
-    ccall((:cairo_surface_write_to_png_stream,_jl_libcairo), Void,
-          (Ptr{UInt8},Ptr{Void},Any), surface.ptr, callback, stream)
+    ccall((:cairo_surface_write_to_png_stream,_jl_libcairo), Nothing,
+          (Ptr{UInt8},Ptr{Nothing},Any), surface.ptr, callback, stream)
 end
 
 function write_to_png(surface::CairoSurface, filename::AbstractString)
-    ccall((:cairo_surface_write_to_png,_jl_libcairo), Void,
+    ccall((:cairo_surface_write_to_png,_jl_libcairo), Nothing,
           (Ptr{UInt8},Ptr{UInt8}), surface.ptr, String(filename))
 end
 
 show(io::IO, ::MIME"image/png", surface::CairoSurface) =
    write_to_png(surface, io)
 
-function read_from_png{T<:IO}(stream::T)
+function read_from_png(stream::T) where {T<:IO}
     callback = get_readstream_callback(T)
     ptr = ccall((:cairo_image_surface_create_from_png_stream, Cairo._jl_libcairo),
-                Ptr{Void}, (Ptr{Void},Ref{IO}), callback, stream)
+                Ptr{Nothing}, (Ptr{Nothing},Ref{IO}), callback, stream)
     w = ccall((:cairo_image_surface_get_width,Cairo._jl_libcairo),
-              Int32, (Ptr{Void},), ptr)
+              Int32, (Ptr{Nothing},), ptr)
     h = ccall((:cairo_image_surface_get_height,Cairo._jl_libcairo),
-              Int32, (Ptr{Void},), ptr)
+              Int32, (Ptr{Nothing},), ptr)
     Cairo.CairoSurface(ptr, w, h)
 end
 
@@ -409,8 +411,8 @@ end
 ## Generic ##
 
 function surface_create_similar(s::CairoSurface, w = width(s), h = height(s))
-    ptr = ccall((:cairo_surface_create_similar,_jl_libcairo), Ptr{Void},
-                (Ptr{Void}, Int32, Int32, Int32),
+    ptr = ccall((:cairo_surface_create_similar,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing}, Int32, Int32, Int32),
                 s.ptr, CONTENT_COLOR_ALPHA, w, h)
     CairoSurface(ptr, w, h)
 end
@@ -425,23 +427,23 @@ end
 
 ## Scripting
 
-type CairoScript <: GraphicsDevice
-    ptr::Ptr{Void}
+mutable struct CairoScript <: GraphicsDevice
+    ptr::Ptr{Nothing}
 
     function CairoScript(filename::AbstractString)
         ptr = ccall((:cairo_script_create,_jl_libcairo),
-                    Ptr{Void}, (Ptr{UInt8},), String(filename))
+                    Ptr{Nothing}, (Ptr{UInt8},), String(filename))
         self = new(ptr)
-        finalizer(self, destroy)
+        @compat finalizer(destroy, self)
         self
     end
 
-    function CairoScript{T<:IO}(stream::T)
+    function CairoScript(stream::T) where {T<:IO}
         callback = get_stream_callback(T)
-        ptr = ccall((:cairo_script_create_for_stream,_jl_libcairo), Ptr{Void},
-                (Ptr{Void}, Any), callback, stream)
+        ptr = ccall((:cairo_script_create_for_stream,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing}, Any), callback, stream)
         self = new(ptr)
-        finalizer(self, destroy)
+        @compat finalizer(destroy, self)
         self
     end
 end
@@ -450,34 +452,34 @@ function destroy(s::CairoScript)
     if s.ptr == C_NULL
         return
     end
-    ccall((:cairo_device_destroy,_jl_libcairo), Void, (Ptr{Void},), s.ptr)
+    ccall((:cairo_device_destroy,_jl_libcairo), Nothing, (Ptr{Nothing},), s.ptr)
     s.ptr = C_NULL
     nothing
 end
 
 function CairoScriptSurface(filename::AbstractString, w::Real, h::Real)
     s = CairoScript(filename)
-    ptr = ccall((:cairo_script_surface_create,_jl_libcairo), Ptr{Void},
-                (Ptr{Void},Int32,Float64,Float64),s.ptr ,CONTENT_COLOR_ALPHA, w, h)
+    ptr = ccall((:cairo_script_surface_create,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing},Int32,Float64,Float64),s.ptr ,CONTENT_COLOR_ALPHA, w, h)
     CairoSurface(ptr, w, h)
 end
 
 function CairoScriptSurface(filename::AbstractString,sc::CairoSurface)
     s = CairoScript(filename)
-    ptr = ccall((:cairo_script_surface_create_for_target,_jl_libcairo), Ptr{Void},
-                (Ptr{Void},Ptr{Void}),s.ptr, sc.ptr)
+    ptr = ccall((:cairo_script_surface_create_for_target,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing},Ptr{Nothing}),s.ptr, sc.ptr)
     CairoSurface(ptr, sc.width, sc.height)
 end
 
-function CairoScriptSurface{T<:IO}(stream::T, w::Real, h::Real)
+function CairoScriptSurface(stream::IO, w::Real, h::Real)
     s = CairoScript(stream)
-    ptr = ccall((:cairo_script_surface_create,_jl_libcairo), Ptr{Void},
-                (Ptr{Void},Int32,Float64,Float64),s.ptr ,CONTENT_COLOR_ALPHA, w, h)
+    ptr = ccall((:cairo_script_surface_create,_jl_libcairo), Ptr{Nothing},
+                (Ptr{Nothing},Int32,Float64,Float64),s.ptr ,CONTENT_COLOR_ALPHA, w, h)
     CairoSurface(ptr, w, h)
 end
 
 
-type CairoRectangle
+mutable struct CairoRectangle
     x0::Float64
     y0::Float64
     x1::Float64
@@ -487,13 +489,13 @@ end
 CairoRectangle() = CairoRectangle(0.0, 0.0, 0.0, 0.0)
 
 function CairoRecordingSurface(content::Int32,extents::CairoRectangle)
-    ptr = ccall((:cairo_recording_surface_create,_jl_libcairo), Ptr{Void},
-                (Int32,Ptr{Void}),content, Ref(extents))
+    ptr = ccall((:cairo_recording_surface_create,_jl_libcairo), Ptr{Nothing},
+                (Int32,Ptr{Nothing}),content, Ref(extents))
     CairoSurface(ptr)
 end
 function CairoRecordingSurface(content::Int32)
-    ptr = ccall((:cairo_recording_surface_create,_jl_libcairo), Ptr{Void},
-                (Int32,Ptr{Void}),content, C_NULL)
+    ptr = ccall((:cairo_recording_surface_create,_jl_libcairo), Ptr{Nothing},
+                (Int32,Ptr{Nothing}),content, C_NULL)
     CairoSurface(ptr)
 end
 
@@ -502,34 +504,34 @@ CairoRecordingSurface() = CairoRecordingSurface(CONTENT_COLOR_ALPHA)
 
 function script_from_recording_surface(s::CairoScript,r::CairoSurface)
     ccall((:cairo_script_from_recording_surface,_jl_libcairo), Int32,
-                (Ptr{Void},Ptr{Void}),s.ptr, r.ptr)
+                (Ptr{Nothing},Ptr{Nothing}),s.ptr, r.ptr)
 end
 # -----------------------------------------------------------------------------
 
-type CairoContext <: GraphicsContext
-    ptr::Ptr{Void}
+mutable struct CairoContext <: GraphicsContext
+    ptr::Ptr{Nothing}
     surface::CairoSurface
-    layout::Ptr{Void} # cache PangoLayout
+    layout::Ptr{Nothing} # cache PangoLayout
 
     function CairoContext(surface::CairoSurface)
         ptr = ccall((:cairo_create,_jl_libcairo),
-                    Ptr{Void}, (Ptr{Void},), surface.ptr)
+                    Ptr{Nothing}, (Ptr{Nothing},), surface.ptr)
         layout = ccall((:pango_cairo_create_layout,_jl_libpangocairo),
-                       Ptr{Void}, (Ptr{Void},), ptr)
+                       Ptr{Nothing}, (Ptr{Nothing},), ptr)
         self = new(ptr, surface, layout)
-        finalizer(self, destroy)
+        @compat finalizer(destroy, self)
         self
     end
-    function CairoContext(ptr::Ptr{Void})
+    function CairoContext(ptr::Ptr{Nothing})
         ccall((:cairo_reference,_jl_libcairo),
-                   Ptr{Void}, (Ptr{Void},), ptr)
+                   Ptr{Nothing}, (Ptr{Nothing},), ptr)
         surface_p = ccall((:cairo_get_target,_jl_libcairo),
-                   Ptr{Void}, (Ptr{Void},), ptr)
+                   Ptr{Nothing}, (Ptr{Nothing},), ptr)
         surface = CairoSurface(surface_p)
         layout = ccall((:pango_cairo_create_layout,_jl_libpangocairo),
-                  Ptr{Void}, (Ptr{Void},), ptr)
+                  Ptr{Nothing}, (Ptr{Nothing},), ptr)
         self = new(ptr,surface,layout)
-        finalizer(self, destroy)
+        @compat finalizer(destroy, self)
         self
     end
 
@@ -542,7 +544,7 @@ function destroy(ctx::CairoContext)
     if ctx.ptr == C_NULL
         return
     end
-    ccall((:g_object_unref,_jl_libgobject), Void, (Ptr{Void},), ctx.layout)
+    ccall((:g_object_unref,_jl_libgobject), Nothing, (Ptr{Nothing},), ctx.layout)
     _destroy(ctx)
     ctx.ptr = C_NULL
     nothing
@@ -592,7 +594,7 @@ for (NAME, FUNCTION) in Any[(:_destroy, :cairo_destroy),
     @eval begin
         $NAME(ctx::CairoContext) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},), ctx.ptr)
+                  Nothing, (Ptr{Nothing},), ctx.ptr)
     end
 end
 
@@ -600,24 +602,24 @@ function stroke(ctx::CairoContext)
     save(ctx)
     # use uniform scale for stroking
     reset_transform(ctx)
-    ccall((:cairo_stroke, _jl_libcairo), Void, (Ptr{Void},), ctx.ptr)
+    ccall((:cairo_stroke, _jl_libcairo), Nothing, (Ptr{Nothing},), ctx.ptr)
     restore(ctx)
 end
 
 function stroke_preserve(ctx::CairoContext)
     save(ctx)
     reset_transform(ctx)
-    ccall((:cairo_stroke_preserve, _jl_libcairo), Void, (Ptr{Void},), ctx.ptr)
+    ccall((:cairo_stroke_preserve, _jl_libcairo), Nothing, (Ptr{Nothing},), ctx.ptr)
     restore(ctx)
 end
 
 function paint_with_alpha(ctx::CairoContext, a)
     ccall((:cairo_paint_with_alpha, _jl_libcairo),
-          Void, (Ptr{Void}, Float64), ctx.ptr, a)
+          Nothing, (Ptr{Nothing}, Float64), ctx.ptr, a)
 end
 
 function get_operator(ctx::CairoContext)
-    Int(ccall((:cairo_get_operator,_jl_libcairo), Int32, (Ptr{Void},), ctx.ptr))
+    Int(ccall((:cairo_get_operator,_jl_libcairo), Int32, (Ptr{Nothing},), ctx.ptr))
 end
 
 
@@ -628,7 +630,7 @@ for (NAME, FUNCTION) in Any[(:set_fill_type, :cairo_set_fill_rule),
     @eval begin
         $NAME(ctx::CairoContext, i0::Integer) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},Int32), ctx.ptr, i0)
+                  Nothing, (Ptr{Nothing},Int32), ctx.ptr, i0)
     end
 end
 
@@ -638,7 +640,7 @@ for (NAME, FUNCTION) in Any[(:set_line_width, :cairo_set_line_width),
     @eval begin
         $NAME(ctx::CairoContext, d0::Real) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},Float64), ctx.ptr, d0)
+                  Nothing, (Ptr{Nothing},Float64), ctx.ptr, d0)
     end
 end
 
@@ -651,7 +653,7 @@ for (NAME, FUNCTION) in Any[(:line_to, :cairo_line_to),
     @eval begin
         $NAME(ctx::CairoContext, d0::Real, d1::Real) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},Float64,Float64), ctx.ptr, d0, d1)
+                  Nothing, (Ptr{Nothing},Float64,Float64), ctx.ptr, d0, d1)
     end
 end
 
@@ -660,7 +662,7 @@ for (NAME, FUNCTION) in Any[(:curve_to, :cairo_curve_to),
     @eval begin
         $NAME(ctx::CairoContext, d0::Real, d1::Real, d2::Real, d3::Real, d4::Real, d5::Real) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},Float64,Float64,Float64,Float64,Float64,Float64), ctx.ptr, d0, d1, d2, d3, d4, d5)
+                  Nothing, (Ptr{Nothing},Float64,Float64,Float64,Float64,Float64,Float64), ctx.ptr, d0, d1, d2, d3, d4, d5)
     end
 end
 
@@ -669,7 +671,7 @@ for (NAME, FUNCTION) in Any[(:arc, :cairo_arc),
     @eval begin
         $NAME(ctx::CairoContext, xc::Real, yc::Real, radius::Real, angle1::Real, angle2::Real) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},Float64,Float64,Float64,Float64,Float64),
+                  Nothing, (Ptr{Nothing},Float64,Float64,Float64,Float64,Float64),
                   ctx.ptr, xc, yc, radius, angle1, angle2)
     end
 end
@@ -677,11 +679,11 @@ end
 
 set_source_rgb(ctx::CairoContext, r::Real, g::Real, b::Real) =
     ccall((:cairo_set_source_rgb,_jl_libcairo),
-          Void, (Ptr{Void},Float64,Float64,Float64), ctx.ptr, r, g, b)
+          Nothing, (Ptr{Nothing},Float64,Float64,Float64), ctx.ptr, r, g, b)
 
 set_source_rgba(ctx::CairoContext, r::Real, g::Real, b::Real, a::Real) =
-    ccall((:cairo_set_source_rgba,_jl_libcairo), Void,
-          (Ptr{Void},Float64,Float64,Float64,Float64),
+    ccall((:cairo_set_source_rgba,_jl_libcairo), Nothing,
+          (Ptr{Nothing},Float64,Float64,Float64,Float64),
           ctx.ptr, r, g, b, a)
 
 function set_source(ctx::CairoContext, c::Color)
@@ -699,18 +701,18 @@ set_source(dest::CairoContext, src::CairoContext) = set_source_surface(dest, src
 set_source(dest::CairoContext, src::CairoSurface) = set_source_surface(dest, src)
 
 rectangle(ctx::CairoContext, x::Real, y::Real, w::Real, h::Real) =
-    ccall((:cairo_rectangle,_jl_libcairo), Void,
-          (Ptr{Void},Float64,Float64,Float64,Float64),
+    ccall((:cairo_rectangle,_jl_libcairo), Nothing,
+          (Ptr{Nothing},Float64,Float64,Float64,Float64),
           ctx.ptr, x, y, w, h)
 
 function set_dash(ctx::CairoContext, dashes::Vector{Float64}, offset::Real = 0.0)
-    ccall((:cairo_set_dash,_jl_libcairo), Void,
-          (Ptr{Void},Ptr{Float64},Int32,Float64), ctx.ptr, dashes, length(dashes), offset)
+    ccall((:cairo_set_dash,_jl_libcairo), Nothing,
+          (Ptr{Nothing},Ptr{Float64},Int32,Float64), ctx.ptr, dashes, length(dashes), offset)
 end
 
 function set_source_surface(ctx::CairoContext, s::CairoSurface, x::Real = 0.0, y::Real = 0.0)
-    ccall((:cairo_set_source_surface,_jl_libcairo), Void,
-          (Ptr{Void},Ptr{Void},Float64,Float64), ctx.ptr, s.ptr, x, y)
+    ccall((:cairo_set_source_surface,_jl_libcairo), Nothing,
+          (Ptr{Nothing},Ptr{Nothing},Float64,Float64), ctx.ptr, s.ptr, x, y)
 end
 
 function set_source(ctx::CairoContext, s::CairoSurface, x::Real, y::Real)
@@ -720,24 +722,24 @@ end
 
 # cairo_path data and functions
 
-type CairoPath_t
+mutable struct CairoPath_t
     status::Cairo.status_t
     data::Ptr{Float64}
     num_data::UInt32
 end
 
-type CairoPath <: GraphicsDevice
+mutable struct CairoPath <: GraphicsDevice
     ptr::Ptr{CairoPath_t}
 
-    function CairoPath(ptr::Ptr{Void})
+    function CairoPath(ptr::Ptr{Nothing})
         self = new(ptr)
-        finalizer(self, destroy)
+        @compat finalizer(destroy, self)
         self
     end
 end
 
 # Abstract, contains type (moveto,lineto,curveto,closepath) and points
-type CairoPathEntry
+mutable struct CairoPathEntry
     element_type::UInt32
     points::Array{Float64,1}
 end
@@ -747,24 +749,24 @@ function destroy(path::CairoPath)
     if path.ptr == C_NULL
         return
     end
-    ccall((:cairo_path_destroy,_jl_libcairo), Void, (Ptr{Void},), path.ptr)
+    ccall((:cairo_path_destroy,_jl_libcairo), Nothing, (Ptr{Nothing},), path.ptr)
     path.ptr = C_NULL
     nothing
 end
 
 function copy_path(ctx::CairoContext)
     ptr = ccall((:cairo_copy_path, _jl_libcairo),
-                    Ptr{Void}, (Ptr{Void},),ctx.ptr)
+                    Ptr{Nothing}, (Ptr{Nothing},),ctx.ptr)
     path = CairoPath(ptr)
-    finalizer(path, destroy)
+    @compat finalizer(destroy, path)
     path
 end
 
 function copy_path_flat(ctx::CairoContext)
     ptr = ccall((:cairo_copy_path_flat, _jl_libcairo),
-                    Ptr{Void}, (Ptr{Void},),ctx.ptr)
+                    Ptr{Nothing}, (Ptr{Nothing},),ctx.ptr)
     path = CairoPath(ptr)
-    finalizer(path, destroy)
+    @compat finalizer(destroy, path)
     path
 end
 
@@ -775,7 +777,7 @@ function convert_cairo_path_data(p::CairoPath)
     # define here by Float64 (most data is) and reinterpret in the header.
 
     path_data = CairoPathEntry[]
-    c_data = unsafe_wrap(Array,c.data,(Int(c.num_data*2),1),false)
+    c_data = unsafe_wrap(Array, c.data, (Int(c.num_data*2), 1), false)
 
     data_index = 1
     while data_index <= ((c.num_data)*2)
@@ -785,7 +787,7 @@ function convert_cairo_path_data(p::CairoPath)
         element_type = reinterpret(UInt64,c_data[data_index]) & 0xffffffff
 
         # copy points x,y
-        points = Vector{Float64}((element_length - 1) * 2)
+        points = Vector{Float64}(uninitialized, (element_length - 1) * 2)
         for i=1:(element_length-1)*2
             points[i] = c_data[data_index+i+1]
         end
@@ -810,7 +812,7 @@ for (fname,cname) in ((:user_to_device!,:cairo_user_to_device),
     @eval begin
         function ($fname)(ctx::CairoContext, p::Vector{Float64})
             ccall(($(Expr(:quote,cname)),_jl_libcairo),
-                  Void, (Ptr{Void}, Ptr{Float64}, Ptr{Float64}),
+                  Nothing, (Ptr{Nothing}, Ptr{Float64}, Ptr{Float64}),
                   ctx.ptr, pointer(p,1), pointer(p,2))
             p
         end
@@ -841,7 +843,7 @@ function push_group(ctx::CairoContext)
     if ctx.ptr == C_NULL
         return
     end
-    ccall((:cairo_push_group, _jl_libcairo), Void, (Ptr{Void},),ctx.ptr)
+    ccall((:cairo_push_group, _jl_libcairo), Nothing, (Ptr{Nothing},),ctx.ptr)
     nothing
 end
 
@@ -849,99 +851,99 @@ function pop_group(ctx::CairoContext)
     if ctx.ptr == C_NULL
         return
     end
-    ptr = ccall((:cairo_pop_group, _jl_libcairo), Ptr{Void}, (Ptr{Void},),ctx.ptr)
+    ptr = ccall((:cairo_pop_group, _jl_libcairo), Ptr{Nothing}, (Ptr{Nothing},),ctx.ptr)
     pattern = CairoPattern(ptr)
-    finalizer(pattern, destroy)
+    @compat finalizer(destroy, pattern)
     pattern
 end
 
 # -----------------------------------------------------------------------------
 
-type CairoPattern
-    ptr::Ptr{Void}
+mutable struct CairoPattern
+    ptr::Ptr{Nothing}
 end
 
 function CairoPattern(s::CairoSurface)
     ptr = ccall((:cairo_pattern_create_for_surface, _jl_libcairo),
-                    Ptr{Void}, (Ptr{Void},), s.ptr)
+                    Ptr{Nothing}, (Ptr{Nothing},), s.ptr)
     # Ideally we'd check the status, but at least for certain releases of the library
     # the return value seems not to be set properly (random values are returned)
 #     status = ccall((:cairo_pattern_status, _jl_libcairo),
-#                     Cint, (Ptr{Void},), s.ptr)
+#                     Cint, (Ptr{Nothing},), s.ptr)
 #     if status != 0
 #         error("Error creating Cairo pattern: ", bytestring(
 #               ccall((:cairo_status_to_string, _jl_libcairo),
 #                     Ptr{UInt8}, (Cint,), status)))
 #     end
     pattern = CairoPattern(ptr)
-    finalizer(pattern, destroy)
+    @compat finalizer(destroy, pattern)
     pattern
 end
 
 set_source(dest::CairoContext, src::CairoPattern) =
     ccall((:cairo_set_source, _jl_libcairo),
-          Void, (Ptr{Void}, Ptr{Void}), dest.ptr, src.ptr)
+          Nothing, (Ptr{Nothing}, Ptr{Nothing}), dest.ptr, src.ptr)
 
 function get_source(ctx::CairoContext)
     CairoPattern(ccall((:cairo_get_source,_jl_libcairo),
-                       Ptr{Void}, (Ptr{Void},), ctx.ptr))
+                       Ptr{Nothing}, (Ptr{Nothing},), ctx.ptr))
 end
 
 function pattern_set_filter(p::CairoPattern, f)
-    ccall((:cairo_pattern_set_filter,_jl_libcairo), Void,
-          (Ptr{Void},Int32), p.ptr, f)
+    ccall((:cairo_pattern_set_filter,_jl_libcairo), Nothing,
+          (Ptr{Nothing},Int32), p.ptr, f)
 end
 
 function pattern_set_extend(p::CairoPattern, val)
-    ccall((:cairo_pattern_set_extend,_jl_libcairo), Void,
-          (Ptr{Void},Int32), p.ptr, val)
+    ccall((:cairo_pattern_set_extend,_jl_libcairo), Nothing,
+          (Ptr{Nothing},Int32), p.ptr, val)
 end
 
 function pattern_create_radial(cx0::Real, cy0::Real, radius0::Real, cx1::Real, cy1::Real, radius1::Real)
     ptr = ccall((:cairo_pattern_create_radial, _jl_libcairo),
-                    Ptr{Void}, (Float64,Float64,Float64,Float64,Float64,Float64),cx0,cy0,radius0,cx1,cy1,radius1)
+                    Ptr{Nothing}, (Float64,Float64,Float64,Float64,Float64,Float64),cx0,cy0,radius0,cx1,cy1,radius1)
     pattern = CairoPattern(ptr)
-    finalizer(pattern, destroy)
+    @compat finalizer(destroy, pattern)
     pattern
 end
 
 function pattern_create_linear(x0::Real, y0::Real, x1::Real, y1::Real)
     ptr = ccall((:cairo_pattern_create_linear, _jl_libcairo),
-                    Ptr{Void}, (Float64,Float64,Float64,Float64),x0,y0,x1,y1)
+                    Ptr{Nothing}, (Float64,Float64,Float64,Float64),x0,y0,x1,y1)
     pattern = CairoPattern(ptr)
-    finalizer(pattern, destroy)
+    @compat finalizer(destroy, pattern)
     pattern
 end
 
 function pattern_add_color_stop_rgb(pat::CairoPattern, offset::Real, red::Real, green::Real, blue::Real)
     ccall((:cairo_pattern_add_color_stop_rgb, _jl_libcairo),
-                    Void, (Ptr{Void},Float64,Float64,Float64,Float64),pat.ptr,offset,red,green,blue)
+                    Nothing, (Ptr{Nothing},Float64,Float64,Float64,Float64),pat.ptr,offset,red,green,blue)
 end
 
 function pattern_add_color_stop_rgba(pat::CairoPattern, offset::Real, red::Real, green::Real, blue::Real, alpha::Real)
     ccall((:cairo_pattern_add_color_stop_rgba, _jl_libcairo),
-                    Void, (Ptr{Void},Float64,Float64,Float64,Float64,Float64),pat.ptr,offset,red,green,blue,alpha)
+                    Nothing, (Ptr{Nothing},Float64,Float64,Float64,Float64,Float64),pat.ptr,offset,red,green,blue,alpha)
 end
 
 function pattern_get_surface(pat::CairoPattern)
-    ptrref = Ref{Ptr{Void}}()
+    ptrref = Ref{Ptr{Nothing}}()
     status = ccall((:cairo_pattern_get_surface, _jl_libcairo), Cint,
-                   (Ptr{Void}, Ref{Ptr{Void}}), pat.ptr, ptrref)
+                   (Ptr{Nothing}, Ref{Ptr{Nothing}}), pat.ptr, ptrref)
     if status == STATUS_PATTERN_TYPE_MISMATCH
         error("Cannot get surface from a non-surface pattern.")
     end
     ptr = ptrref.x
 
-    ccall((:cairo_surface_reference, _jl_libcairo), Ptr{Void}, (Ptr{Void},), ptr)
-    typ = ccall((:cairo_surface_get_type, _jl_libcairo), Cint, (Ptr{Void},), ptr)
+    ccall((:cairo_surface_reference, _jl_libcairo), Ptr{Nothing}, (Ptr{Nothing},), ptr)
+    typ = ccall((:cairo_surface_get_type, _jl_libcairo), Cint, (Ptr{Nothing},), ptr)
 
     w = 0.0
     h = 0.0
     if typ == CAIRO_SURFACE_TYPE_IMAGE
         w = ccall((:cairo_image_surface_get_width, _jl_libcairo),
-                  Int32, (Ptr{Void},), ptr)
+                  Int32, (Ptr{Nothing},), ptr)
         h = ccall((:cairo_image_surface_get_height, _jl_libcairo),
-                  Int32, (Ptr{Void},), ptr)
+                  Int32, (Ptr{Nothing},), ptr)
     end
     return CairoSurface(ptr, w, h)
 end
@@ -950,7 +952,7 @@ function destroy(pat::CairoPattern)
     if pat.ptr == C_NULL
         return
     end
-    ccall((:cairo_pattern_destroy,_jl_libcairo), Void, (Ptr{Void},), pat.ptr)
+    ccall((:cairo_pattern_destroy,_jl_libcairo), Nothing, (Ptr{Nothing},), pat.ptr)
     pat.ptr = C_NULL
     nothing
 end
@@ -960,16 +962,16 @@ end
 # create mesh pattern
 function CairoPatternMesh()
     ptr = ccall((:cairo_pattern_create_mesh, _jl_libcairo),
-                    Ptr{Void}, ())
+                    Ptr{Nothing}, ())
     pattern = CairoPattern(ptr)
     #status = ccall((:cairo_pattern_status, _jl_libcairo),
-    #                Cint, (Ptr{Void},), pattern.ptr)
+    #                Cint, (Ptr{Nothing},), pattern.ptr)
     #if status != 0
     #    error("Error creating Cairo pattern: ", bytestring(
     #          ccall((:cairo_status_to_string, _jl_libcairo),
     #                Ptr{Uint8}, (Cint,), status)))
     #end
-    finalizer(pattern, destroy)
+    @compat finalizer(destroy, pattern)
     pattern
 end
 
@@ -979,7 +981,7 @@ end
 #    @eval begin
 #        $NAME(ctx::CairoContext, d0::Real) =
 #            ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-#                  Void, (Ptr{Void},Float64), ctx.ptr, d0)
+#                  Nothing, (Ptr{Nothing},Float64), ctx.ptr, d0)
 #    end
 #end
 
@@ -988,7 +990,7 @@ for (NAME, FUNCTION) in Any[(:mesh_pattern_begin_patch, :cairo_mesh_pattern_begi
     @eval begin
         $NAME(pattern::CairoPattern) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},), pattern.ptr)
+                  Nothing, (Ptr{Nothing},), pattern.ptr)
     end
 end
 
@@ -997,7 +999,7 @@ for (NAME, FUNCTION) in Any[(:mesh_pattern_line_to, :cairo_mesh_pattern_line_to)
     @eval begin
         $NAME(pattern::CairoPattern, d0::Real, d1::Real) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},Float64,Float64), pattern.ptr, d0, d1)
+                  Nothing, (Ptr{Nothing},Float64,Float64), pattern.ptr, d0, d1)
     end
 end
 
@@ -1006,34 +1008,34 @@ for (NAME, FUNCTION) in Any[(:mesh_pattern_curve_to, :cairo_mesh_pattern_curve_t
     @eval begin
         $NAME(pattern::CairoPattern, d0::Real, d1::Real, d2::Real, d3::Real, d4::Real, d5::Real) =
             ccall(($(Expr(:quote,FUNCTION)),_jl_libcairo),
-                  Void, (Ptr{Void},Float64,Float64,Float64,Float64,Float64,Float64), pattern.ptr, d0, d1, d2, d3, d4, d5)
+                  Nothing, (Ptr{Nothing},Float64,Float64,Float64,Float64,Float64,Float64), pattern.ptr, d0, d1, d2, d3, d4, d5)
     end
 end
 
 
 function mesh_pattern_set_corner_color_rgb(pat::CairoPattern, corner_num::Real, red::Real, green::Real, blue::Real)
     ccall((:cairo_mesh_pattern_set_corner_color_rgb, _jl_libcairo),
-                    Void, (Ptr{Void},Int32,Float64,Float64,Float64),pat.ptr,corner_num,red,green,blue)
+                    Nothing, (Ptr{Nothing},Int32,Float64,Float64,Float64),pat.ptr,corner_num,red,green,blue)
 end
 
 function mesh_pattern_set_corner_color_rgba(pat::CairoPattern, corner_num::Real, red::Real, green::Real, blue::Real, alpha::Real)
     ccall((:cairo_mesh_pattern_set_corner_color_rgba, _jl_libcairo),
-                    Void, (Ptr{Void},Int32,Float64,Float64,Float64,Float64),pat.ptr,corner_num,red,green,blue,alpha)
+                    Nothing, (Ptr{Nothing},Int32,Float64,Float64,Float64,Float64),pat.ptr,corner_num,red,green,blue,alpha)
 end
 
 # ----
 
 set_antialias(ctx::CairoContext, a) =
-    ccall((:cairo_set_antialias,_jl_libcairo), Void,
-          (Ptr{Void},Cint), ctx.ptr, a)
+    ccall((:cairo_set_antialias,_jl_libcairo), Nothing,
+          (Ptr{Nothing},Cint), ctx.ptr, a)
 
 get_antialias(ctx::CairoContext) =
     ccall((:cairo_get_antialias,_jl_libcairo), Cint,
-          (Ptr{Void},), ctx.ptr)
+          (Ptr{Nothing},), ctx.ptr)
 
 # -----------------------------------------------------------------------------
 
-immutable CairoMatrix
+struct CairoMatrix
     xx::Float64
     yx::Float64
     xy::Float64
@@ -1046,16 +1048,16 @@ CairoMatrix() = CairoMatrix(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
 function get_matrix(ctx::CairoContext)
     m = [CairoMatrix()]
-    ccall((:cairo_get_matrix, _jl_libcairo), Void, (Ptr{Void}, Ptr{Void}), ctx.ptr, m)
+    ccall((:cairo_get_matrix, _jl_libcairo), Nothing, (Ptr{Nothing}, Ptr{Nothing}), ctx.ptr, m)
     m[1]
 end
 
 function set_matrix(ctx::CairoContext, m::CairoMatrix)
-    ccall((:cairo_set_matrix, _jl_libcairo), Void, (Ptr{Void}, Ptr{Void}), ctx.ptr, [m])
+    ccall((:cairo_set_matrix, _jl_libcairo), Nothing, (Ptr{Nothing}, Ptr{Nothing}), ctx.ptr, [m])
 end
 
 function set_matrix(p::CairoPattern, m::CairoMatrix)
-    ccall((:cairo_pattern_set_matrix, _jl_libcairo), Void, (Ptr{Void}, Ptr{Void}), p.ptr, [m])
+    ccall((:cairo_pattern_set_matrix, _jl_libcairo), Nothing, (Ptr{Nothing}, Ptr{Nothing}), p.ptr, [m])
 end
 
 
@@ -1086,46 +1088,47 @@ end
 
 function set_font_face(ctx::CairoContext, str::AbstractString)
     fontdesc = ccall((:pango_font_description_from_string,_jl_libpango),
-                     Ptr{Void}, (Ptr{UInt8},), String(str))
-    ccall((:pango_layout_set_font_description,_jl_libpango), Void,
-          (Ptr{Void},Ptr{Void}), ctx.layout, fontdesc)
-    ccall((:pango_font_description_free,_jl_libpango), Void,
-          (Ptr{Void},), fontdesc)
+                     Ptr{Nothing}, (Ptr{UInt8},), String(str))
+    ccall((:pango_layout_set_font_description,_jl_libpango), Nothing,
+          (Ptr{Nothing},Ptr{Nothing}), ctx.layout, fontdesc)
+    ccall((:pango_font_description_free,_jl_libpango), Nothing,
+          (Ptr{Nothing},), fontdesc)
 end
 
 function set_text(ctx::CairoContext, text::AbstractString, markup::Bool = false)
     if markup
-        ccall((:pango_layout_set_markup,_jl_libpango), Void,
-            (Ptr{Void},Ptr{UInt8},Int32), ctx.layout, String(text), -1)
+        ccall((:pango_layout_set_markup,_jl_libpango), Nothing,
+            (Ptr{Nothing},Ptr{UInt8},Int32), ctx.layout, String(text), -1)
     else
-        ccall((:pango_layout_set_text,_jl_libpango), Void,
-            (Ptr{Void},Ptr{UInt8},Int32), ctx.layout, String(text), -1)
+        ccall((:pango_layout_set_text,_jl_libpango), Nothing,
+            (Ptr{Nothing},Ptr{UInt8},Int32), ctx.layout, String(text), -1)
     end
     text
 end
 
 function get_layout_size(ctx::CairoContext)
-    w = Vector{Int32}(2)
-    ccall((:pango_layout_get_pixel_size,_jl_libpango), Void,
-          (Ptr{Void},Ptr{Int32},Ptr{Int32}), ctx.layout, pointer(w,1), pointer(w,2))
+    w = Vector{Int32}(uninitialized, 2)
+    ccall((:pango_layout_get_pixel_size,_jl_libpango), Nothing,
+          (Ptr{Nothing},Ptr{Int32},Ptr{Int32}), ctx.layout, pointer(w,1), pointer(w,2))
     w
 end
 
 function update_layout(ctx::CairoContext)
-    ccall((:pango_cairo_update_layout,_jl_libpangocairo), Void,
-          (Ptr{Void},Ptr{Void}), ctx.ptr, ctx.layout)
+    ccall((:pango_cairo_update_layout,_jl_libpangocairo), Nothing,
+          (Ptr{Nothing},Ptr{Nothing}), ctx.ptr, ctx.layout)
 end
 
 function show_layout(ctx::CairoContext)
-    ccall((:pango_cairo_show_layout,_jl_libpangocairo), Void,
-          (Ptr{Void},Ptr{Void}), ctx.ptr, ctx.layout)
+    ccall((:pango_cairo_show_layout,_jl_libpangocairo), Nothing,
+          (Ptr{Nothing},Ptr{Nothing}), ctx.ptr, ctx.layout)
 end
 
-text_extents(ctx::CairoContext,value::AbstractString) = text_extents!(ctx,value, Matrix{Float64}(6, 1))
+text_extents(ctx::CairoContext,value::AbstractString) =
+    text_extents!(ctx,value, Matrix{Float64}(uninitialized, 6, 1))
 
 function text_extents!(ctx::CairoContext,value::AbstractString,extents)
     ccall((:cairo_text_extents, _jl_libcairo),
-          Void, (Ptr{Void}, Ptr{UInt8}, Ptr{Float64}),
+          Nothing, (Ptr{Nothing}, Ptr{UInt8}, Ptr{Float64}),
           ctx.ptr, String(value), extents)
     extents
 end
@@ -1137,7 +1140,7 @@ function path_extents(ctx::CairoContext)
     dy2 = Cdouble[0]
 
     ccall((:cairo_path_extents, _jl_libcairo),
-          Void, (Ptr{Void}, Ptr{Cdouble}, Ptr{Cdouble},
+          Nothing, (Ptr{Nothing}, Ptr{Cdouble}, Ptr{Cdouble},
           Ptr{Cdouble}, Ptr{Cdouble}),
           ctx.ptr, dx1, dy1, dx2, dy2)
 
@@ -1147,20 +1150,20 @@ end
 
 function show_text(ctx::CairoContext,value::AbstractString)
     ccall((:cairo_show_text, _jl_libcairo),
-          Void, (Ptr{Void}, Ptr{UInt8}),
+          Nothing, (Ptr{Nothing}, Ptr{UInt8}),
           ctx.ptr, String(value))
 end
 
 function text_path(ctx::CairoContext,value::AbstractString)
     ccall((:cairo_text_path, _jl_libcairo),
-          Void, (Ptr{Void}, Ptr{UInt8}),
+          Nothing, (Ptr{Nothing}, Ptr{UInt8}),
           ctx.ptr, String(value))
 end
 
 
 function select_font_face(ctx::CairoContext,family::AbstractString,slant,weight)
     ccall((:cairo_select_font_face, _jl_libcairo),
-          Void, (Ptr{Void}, Ptr{UInt8},
+          Nothing, (Ptr{Nothing}, Ptr{UInt8},
                  font_slant_t, font_weight_t),
           ctx.ptr, String(family),
           slant, weight)
@@ -1211,7 +1214,7 @@ end
 
 set_latex(ctx::CairoContext, str::AbstractString, fontsize::Real) = set_text(ctx, tex2pango(str, fontsize), true)
 
-type TeXLexer
+mutable struct TeXLexer
     str::String
     len::Int
     pos::Int
@@ -1219,7 +1222,7 @@ type TeXLexer
 
     function TeXLexer(str::AbstractString)
         s = String(str)
-        new(s, endof(s), 1, String[])
+        new(s, lastindex(s), 1, String[])
     end
 end
 
@@ -1363,7 +1366,7 @@ end
 @deprecate layout_text(ctx::CairoContext, str::AbstractString, fontsize::Real)       set_latex(ctx, str, fontsize)
 @deprecate textwidth(ctx::CairoContext, str::AbstractString, fontsize::Real)         textwidth(ctx, tex2pango(str, fontsize), true)
 @deprecate textheight(ctx::CairoContext, str::AbstractString, fontsize::Real)        textheight(ctx, tex2pango(str, fontsize), true)
-@deprecate cairo_write_to_ios_callback(s::Ptr{Void}, buf::Ptr{UInt8}, len::UInt32)   write_to_ios_callback(s, buf, len)
+@deprecate cairo_write_to_ios_callback(s::Ptr{Nothing}, buf::Ptr{UInt8}, len::UInt32)   write_to_ios_callback(s, buf, len)
 @deprecate cairo_write_to_stream_callback(s::IO, buf::Ptr{UInt8}, len::UInt32)       write_to_stream_callback(s, buf, len)
 @deprecate text_extents(ctx::CairoContext,value::AbstractString,extents) text_extents!(ctx,value,extents)
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -17,95 +17,95 @@ export CAIRO_FORMAT_ARGB32,
     CAIRO_FILTER_GAUSSIAN
 
 const format_t = Int32
-const FORMAT_INVALID   = @compat Int32(-1)
-const FORMAT_ARGB32    = @compat Int32(0)
-const FORMAT_RGB24     = @compat Int32(1)
-const FORMAT_A8        = @compat Int32(2)
-const FORMAT_A1        = @compat Int32(3)
-const FORMAT_RGB16_565 = @compat Int32(4)
-const FORMAT_RGB30     = @compat Int32(5)
+const FORMAT_INVALID   = Int32(-1)
+const FORMAT_ARGB32    = Int32(0)
+const FORMAT_RGB24     = Int32(1)
+const FORMAT_A8        = Int32(2)
+const FORMAT_A1        = Int32(3)
+const FORMAT_RGB16_565 = Int32(4)
+const FORMAT_RGB30     = Int32(5)
 
 const status_t = Int32
-const STATUS_SUCCESS                   = @compat Int32(0)
-const STATUS_NO_MEMORY                 = @compat Int32(1)
-const STATUS_INVALID_RESTORE           = @compat Int32(2)
-const STATUS_INVALID_POP_GROUP         = @compat Int32(3)
-const STATUS_NO_CURRENT_POINT          = @compat Int32(4)
-const STATUS_INVALID_MATRIX            = @compat Int32(5)
-const STATUS_INVALID_STATUS            = @compat Int32(6)
-const STATUS_NULL_POINTER              = @compat Int32(7)
-const STATUS_INVALID_STRING            = @compat Int32(8)
-const STATUS_INVALID_PATH_DATA         = @compat Int32(9)
-const STATUS_READ_ERROR                = @compat Int32(10)
-const STATUS_WRITE_ERROR               = @compat Int32(11)
-const STATUS_SURFACE_FINISHED          = @compat Int32(12)
-const STATUS_SURFACE_TYPE_MISMATCH     = @compat Int32(13)
-const STATUS_PATTERN_TYPE_MISMATCH     = @compat Int32(14)
-const STATUS_INVALID_CONTENT           = @compat Int32(15)
-const STATUS_INVALID_FORMAT            = @compat Int32(16)
-const STATUS_INVALID_VISUAL            = @compat Int32(17)
-const STATUS_FILE_NOT_FOUND            = @compat Int32(17)
-const STATUS_INVALID_DASH              = @compat Int32(18)
-const STATUS_INVALID_DSC_COMMENT       = @compat Int32(19)
-const STATUS_INVALID_INDEX             = @compat Int32(20)
-const STATUS_CLIP_NOT_REPRESENTABLE    = @compat Int32(21)
-const STATUS_TEMP_FILE_ERROR           = @compat Int32(22)
-const STATUS_INVALID_STRIDE            = @compat Int32(23)
-const STATUS_FONT_TYPE_MISMATCH        = @compat Int32(24)
-const STATUS_USER_FONT_IMMUTABLE       = @compat Int32(25)
-const STATUS_USER_FONT_ERROR           = @compat Int32(26)
-const STATUS_NEGATIVE_COUNT            = @compat Int32(27)
-const STATUS_INVALID_CLUSTERS          = @compat Int32(28)
-const STATUS_INVALID_SLANT             = @compat Int32(29)
-const STATUS_INVALID_WEIGHT            = @compat Int32(30)
-const STATUS_INVALID_SIZE              = @compat Int32(31)
-const STATUS_USER_FONT_NOT_IMPLEMENTED = @compat Int32(32)
-const STATUS_DEVICE_TYPE_MISMATCH      = @compat Int32(33)
-const STATUS_DEVICE_ERROR              = @compat Int32(34)
-const STATUS_INVALID_MESH_CONSTRUCTION = @compat Int32(35)
-const STATUS_DEVICE_FINISHED           = @compat Int32(36)
-const STATUS_LAST_STATUS               = @compat Int32(37)
+const STATUS_SUCCESS                   = Int32(0)
+const STATUS_NO_MEMORY                 = Int32(1)
+const STATUS_INVALID_RESTORE           = Int32(2)
+const STATUS_INVALID_POP_GROUP         = Int32(3)
+const STATUS_NO_CURRENT_POINT          = Int32(4)
+const STATUS_INVALID_MATRIX            = Int32(5)
+const STATUS_INVALID_STATUS            = Int32(6)
+const STATUS_NULL_POINTER              = Int32(7)
+const STATUS_INVALID_STRING            = Int32(8)
+const STATUS_INVALID_PATH_DATA         = Int32(9)
+const STATUS_READ_ERROR                = Int32(10)
+const STATUS_WRITE_ERROR               = Int32(11)
+const STATUS_SURFACE_FINISHED          = Int32(12)
+const STATUS_SURFACE_TYPE_MISMATCH     = Int32(13)
+const STATUS_PATTERN_TYPE_MISMATCH     = Int32(14)
+const STATUS_INVALID_CONTENT           = Int32(15)
+const STATUS_INVALID_FORMAT            = Int32(16)
+const STATUS_INVALID_VISUAL            = Int32(17)
+const STATUS_FILE_NOT_FOUND            = Int32(17)
+const STATUS_INVALID_DASH              = Int32(18)
+const STATUS_INVALID_DSC_COMMENT       = Int32(19)
+const STATUS_INVALID_INDEX             = Int32(20)
+const STATUS_CLIP_NOT_REPRESENTABLE    = Int32(21)
+const STATUS_TEMP_FILE_ERROR           = Int32(22)
+const STATUS_INVALID_STRIDE            = Int32(23)
+const STATUS_FONT_TYPE_MISMATCH        = Int32(24)
+const STATUS_USER_FONT_IMMUTABLE       = Int32(25)
+const STATUS_USER_FONT_ERROR           = Int32(26)
+const STATUS_NEGATIVE_COUNT            = Int32(27)
+const STATUS_INVALID_CLUSTERS          = Int32(28)
+const STATUS_INVALID_SLANT             = Int32(29)
+const STATUS_INVALID_WEIGHT            = Int32(30)
+const STATUS_INVALID_SIZE              = Int32(31)
+const STATUS_USER_FONT_NOT_IMPLEMENTED = Int32(32)
+const STATUS_DEVICE_TYPE_MISMATCH      = Int32(33)
+const STATUS_DEVICE_ERROR              = Int32(34)
+const STATUS_INVALID_MESH_CONSTRUCTION = Int32(35)
+const STATUS_DEVICE_FINISHED           = Int32(36)
+const STATUS_LAST_STATUS               = Int32(37)
 
 const surface_t = Int32
-const CAIRO_SURFACE_TYPE_IMAGE            = @compat Int32(0)
-const CAIRO_SURFACE_TYPE_PDF,             = @compat Int32(1)
-const CAIRO_SURFACE_TYPE_PS,              = @compat Int32(2)
-const CAIRO_SURFACE_TYPE_XLIB,            = @compat Int32(3)
-const CAIRO_SURFACE_TYPE_XCB,             = @compat Int32(4)
-const CAIRO_SURFACE_TYPE_GLITZ,           = @compat Int32(5)
-const CAIRO_SURFACE_TYPE_QUARTZ,          = @compat Int32(6)
-const CAIRO_SURFACE_TYPE_WIN32,           = @compat Int32(7)
-const CAIRO_SURFACE_TYPE_BEOS,            = @compat Int32(8)
-const CAIRO_SURFACE_TYPE_DIRECTFB,        = @compat Int32(9)
-const CAIRO_SURFACE_TYPE_SVG,             = @compat Int32(10)
-const CAIRO_SURFACE_TYPE_OS2,             = @compat Int32(11)
-const CAIRO_SURFACE_TYPE_WIN32_PRINTING,  = @compat Int32(12)
-const CAIRO_SURFACE_TYPE_QUARTZ_IMAGE,    = @compat Int32(13)
-const CAIRO_SURFACE_TYPE_SCRIPT,          = @compat Int32(14)
-const CAIRO_SURFACE_TYPE_QT,              = @compat Int32(15)
-const CAIRO_SURFACE_TYPE_RECORDING,       = @compat Int32(16)
-const CAIRO_SURFACE_TYPE_VG,              = @compat Int32(17)
-const CAIRO_SURFACE_TYPE_GL,              = @compat Int32(18)
-const CAIRO_SURFACE_TYPE_DRM,             = @compat Int32(19)
-const CAIRO_SURFACE_TYPE_TEE,             = @compat Int32(20)
-const CAIRO_SURFACE_TYPE_XML,             = @compat Int32(21)
-const CAIRO_SURFACE_TYPE_SKIA,            = @compat Int32(22)
-const CAIRO_SURFACE_TYPE_SUBSURFACE,      = @compat Int32(23)
-const CAIRO_SURFACE_TYPE_COGL             = @compat Int32(24)
+const CAIRO_SURFACE_TYPE_IMAGE            = Int32(0)
+const CAIRO_SURFACE_TYPE_PDF,             = Int32(1)
+const CAIRO_SURFACE_TYPE_PS,              = Int32(2)
+const CAIRO_SURFACE_TYPE_XLIB,            = Int32(3)
+const CAIRO_SURFACE_TYPE_XCB,             = Int32(4)
+const CAIRO_SURFACE_TYPE_GLITZ,           = Int32(5)
+const CAIRO_SURFACE_TYPE_QUARTZ,          = Int32(6)
+const CAIRO_SURFACE_TYPE_WIN32,           = Int32(7)
+const CAIRO_SURFACE_TYPE_BEOS,            = Int32(8)
+const CAIRO_SURFACE_TYPE_DIRECTFB,        = Int32(9)
+const CAIRO_SURFACE_TYPE_SVG,             = Int32(10)
+const CAIRO_SURFACE_TYPE_OS2,             = Int32(11)
+const CAIRO_SURFACE_TYPE_WIN32_PRINTING,  = Int32(12)
+const CAIRO_SURFACE_TYPE_QUARTZ_IMAGE,    = Int32(13)
+const CAIRO_SURFACE_TYPE_SCRIPT,          = Int32(14)
+const CAIRO_SURFACE_TYPE_QT,              = Int32(15)
+const CAIRO_SURFACE_TYPE_RECORDING,       = Int32(16)
+const CAIRO_SURFACE_TYPE_VG,              = Int32(17)
+const CAIRO_SURFACE_TYPE_GL,              = Int32(18)
+const CAIRO_SURFACE_TYPE_DRM,             = Int32(19)
+const CAIRO_SURFACE_TYPE_TEE,             = Int32(20)
+const CAIRO_SURFACE_TYPE_XML,             = Int32(21)
+const CAIRO_SURFACE_TYPE_SKIA,            = Int32(22)
+const CAIRO_SURFACE_TYPE_SUBSURFACE,      = Int32(23)
+const CAIRO_SURFACE_TYPE_COGL             = Int32(24)
 
 
 const font_slant_t = Int32
-const FONT_SLANT_NORMAL  = @compat Int32(0)
-const FONT_SLANT_ITALIC  = @compat Int32(1)
-const FONT_SLANT_OBLIQUE = @compat Int32(2)
+const FONT_SLANT_NORMAL  = Int32(0)
+const FONT_SLANT_ITALIC  = Int32(1)
+const FONT_SLANT_OBLIQUE = Int32(2)
 
 const font_weight_t = Int32
-const FONT_WEIGHT_NORMAL = @compat Int32(0)
-const FONT_WEIGHT_BOLD = @compat Int32(1)
+const FONT_WEIGHT_NORMAL = Int32(0)
+const FONT_WEIGHT_BOLD = Int32(1)
 
-const CONTENT_COLOR = @compat Int32(0x1000)
-const CONTENT_ALPHA = @compat Int32(0x2000)
-const CONTENT_COLOR_ALPHA = @compat Int32(0x3000)
+const CONTENT_COLOR = Int32(0x1000)
+const CONTENT_ALPHA = Int32(0x2000)
+const CONTENT_COLOR_ALPHA = Int32(0x3000)
 
 const FILTER_FAST = 0
 const FILTER_GOOD = 1
@@ -150,7 +150,7 @@ const OPERATOR_LIGHTEN = 18
 
 
 ## LaTex Token Dicts ##
-const _common_token_dict = @compat Dict(
+const _common_token_dict = Dict(
     "\\{"              => "{",
     "\\}"              => "}",
     "\\_"              => "_",
@@ -162,7 +162,7 @@ const _common_token_dict = @compat Dict(
     "}"                => ""
 )
 
-const _text_token_dict = @compat Dict(
+const _text_token_dict = Dict(
     ## non-math symbols (p438)
     "\\S"              => "\ua7",
     "\\P"              => "\ub6",
@@ -170,7 +170,7 @@ const _text_token_dict = @compat Dict(
     "\\ddag"           => "\u2021"
 )
 
-const _math_token_dict = @compat Dict(
+const _math_token_dict = Dict(
 
     "-"                => "\u2212", # minus sign
 
@@ -423,16 +423,16 @@ const _math_token_dict = @compat Dict(
     "\\arcsec"          => "\u2033"
 )
 
-const CAIRO_FILL_RULE_WINDING = @compat Int32(0);
-const CAIRO_FILL_RULE_EVEN_ODD = @compat Int32(1);
+const CAIRO_FILL_RULE_WINDING = Int32(0);
+const CAIRO_FILL_RULE_EVEN_ODD = Int32(1);
 
-const CAIRO_LINE_CAP_BUTT = @compat Int32(0);
-const CAIRO_LINE_CAP_ROUND = @compat Int32(1);
-const CAIRO_LINE_CAP_SQUARE = @compat Int32(2);
+const CAIRO_LINE_CAP_BUTT = Int32(0);
+const CAIRO_LINE_CAP_ROUND = Int32(1);
+const CAIRO_LINE_CAP_SQUARE = Int32(2);
 
-const CAIRO_LINE_JOIN_MITER = @compat Int32(0);
-const CAIRO_LINE_JOIN_ROUND = @compat Int32(1);
-const CAIRO_LINE_JOIN_BEVEL = @compat Int32(2);
+const CAIRO_LINE_JOIN_MITER = Int32(0);
+const CAIRO_LINE_JOIN_ROUND = Int32(1);
+const CAIRO_LINE_JOIN_BEVEL = Int32(2);
 
 #typedef enum _cairo_path_data_type {
 #    CAIRO_PATH_MOVE_TO,
@@ -441,9 +441,9 @@ const CAIRO_LINE_JOIN_BEVEL = @compat Int32(2);
 #    CAIRO_PATH_CLOSE_PATH
 #} cairo_path_data_type_t;
 
-const CAIRO_PATH_MOVE_TO = @compat Int32(0);
-const CAIRO_PATH_LINE_TO = @compat Int32(1);
-const CAIRO_PATH_CURVE_TO = @compat Int32(2);
-const CAIRO_PATH_CLOSE_PATH = @compat Int32(3);
+const CAIRO_PATH_MOVE_TO = Int32(0);
+const CAIRO_PATH_LINE_TO = Int32(1);
+const CAIRO_PATH_CURVE_TO = Int32(2);
+const CAIRO_PATH_CLOSE_PATH = Int32(3);
 
 

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,0 @@
-BaseTestNext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,14 +2,9 @@ using Cairo
 using Compat, Colors
 import Compat.String
 
-@compat import Base.show
+import Base.show
 
-if VERSION >= v"0.5.0-dev+7720"
-    using Base.Test
-else
-    using BaseTestNext
-    const Test = BaseTestNext
-end
+using Base.Test
 
 
 # Image Surface
@@ -25,7 +20,7 @@ end
     surf = CairoImageSurface(fill(RGB24(0), 10, 10))
     @test Cairo.format(surf) == RGB24
     io = IOBuffer()
-    @compat show(io, MIME("image/png"), surf)
+    show(io, MIME("image/png"), surf)
 
     seek(io,0)
     str_data = Vector{UInt8}(read(io))

--- a/test/shape_functions.jl
+++ b/test/shape_functions.jl
@@ -1,4 +1,4 @@
-using Cairo
+using Cairo, Compat, Random
 
 # shape functions,
 

--- a/test/test_painting.jl
+++ b/test/test_painting.jl
@@ -39,16 +39,16 @@ end
 
 
 function hilbert_colored(surf)
-    
+
     zscale = 8;
     n1 = 8;
     cr = CairoContext(surf)
-    
+
     c = Float64[]
     hilbert_curve(c,0,0,64,0,0)
 
     move_to(cr,0,0)
-    
+
     translate(cr,zscale/2,zscale/2)
     scale(cr,zscale,zscale)
     set_line_width(cr,zscale/2)
@@ -62,13 +62,13 @@ function hilbert_colored(surf)
         set_source_rgb(cr,c1[1]/float(n1-1),c1[2]/float(n1-1),c1[3]/float(n1-1))
         stroke(cr)
 
-    end    
+    end
 end
 
 
 """ function hdraw(s,dim,zscale,linewidth)
 draws a hilbert curve with dimension dim (power of 2) and scales the drawing with
-zscale. 
+zscale.
 """
 function hdraw(s,dim,zscale,linewidth)
 
@@ -79,12 +79,12 @@ function hdraw(s,dim,zscale,linewidth)
     set_line_width(cr,linewidth)
     set_line_cap(cr,Cairo.CAIRO_LINE_CAP_SQUARE)
     translate(cr,zscale/2,zscale/2)
-    
+
     save(cr)
     c = Float64[]
 
     hilbert_curve(c,0,0,dim,0,0)
-    
+
     scale(cr,zscale,zscale)
 
     move_to(cr,0,0)
@@ -93,7 +93,7 @@ function hdraw(s,dim,zscale,linewidth)
     end
 
     stroke(cr)
-    restore(cr)    
+    restore(cr)
 end
 
 """
@@ -118,7 +118,7 @@ end
 """
 function matrix_read(surface)
 	paint the input surface into a matrix image of the same size to access
-	the pixels. 
+	the pixels.
 """
 function matrix_read(surface)
 	w = Int(surface.width)

--- a/test/test_stream.jl
+++ b/test/test_stream.jl
@@ -1,21 +1,24 @@
 # So that this test can be run independently
-using Cairo
+using Cairo, Compat
+using Compat.Base64
+
 if !isdefined(:ddots4)
     include("shape_functions.jl")
 end
 
-# Test that writing images to a Julia IO object works
-c = CairoRGBSurface(256,256);
-cr = CairoContext(c);
-ddots4(cr,256,246,1.0,3000)
-buf = IOBuffer()
-pipe = Base64EncodePipe(buf)
-write_to_png(c,pipe)
-close(pipe)
+@testset "Test that writing images to a Julia IO object works" begin
+    c = CairoRGBSurface(256,256)
+    cr = CairoContext(c)
+    ddots4(cr,256,246,1.0,3000)
+    buf = IOBuffer()
+    pipe = Base64EncodePipe(buf)
+    write_to_png(c,pipe)
+    close(pipe)
 
-# Catch short writes
+    # Catch short writes
 
-str = String(take!(buf))
-str_data = Vector{UInt8}(str)
+    str = String(take!(buf))
+    str_data = codeunits(str)
 
-@assert length(str_data) > 200
+    @test length(str_data) > 200
+end

--- a/test/tex.jl
+++ b/test/tex.jl
@@ -1,5 +1,5 @@
-using Cairo.tex2pango
-using Base.Test
+using Cairo: tex2pango
+using Compat, Test
 
 fsize = 1.618034
 @test tex2pango("ƒ_{Nyquist} [\\mu K]",fsize) == "ƒ<sub><span font=\"1.0\">Nyquist</span></sub> [μK]"


### PR DESCRIPTION
I realized that this work overlapped #197 but at that point, I concluded that it was easier to finish my own branch. This branch is based on FemtoCleaners suggestions and then some changes by hand to remove deprecation warnings. Along the way, I also hit https://github.com/JuliaGraphics/Cairo.jl/issues/215 and added calls to `gc()` as a temporary fix to make tests pass. To avoid pollution of the namespace, I've changed the test of the samples to run each of them in a separate process in parallel with at most four Julia process running concurrently. We might want to add an option to set this number.