### PR TITLE
Fix and add test for reset_transform

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -13,7 +13,7 @@ using Colors
 
 import Graphics
 using Graphics: BoundingBox, GraphicsContext, GraphicsDevice
-import Graphics: arc, clip, close_path, creategc, fill_preserve, height, line_to, move_to, new_path, new_sub_path, paint, rectangle, rel_line_to, reset_clip, restore, rotate, save, scale, set_dash, set_line_width, set_source, set_source_rgb, set_source_rgba, stroke, stroke_preserve, textwidth, translate, width, circle
+import Graphics: arc, clip, close_path, creategc, fill_preserve, height, line_to, move_to, new_path, new_sub_path, paint, rectangle, rel_line_to, reset_clip, restore, rotate, save, scale, set_dash, set_line_width, set_source, set_source_rgb, set_source_rgba, stroke, stroke_preserve, textwidth, translate, width, circle, reset_transform
 import Base: copy, fill
 
 libcairo_version = VersionNumber(unsafe_string(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -325,6 +325,7 @@ end
 end
 
 @testset "reset_transform" begin
+    using Graphics
 
     z = zeros(UInt32,512,512);
     surf = CairoImageSurface(z, Cairo.FORMAT_ARGB32)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -324,4 +324,30 @@ end
     @test_throws ErrorException Cairo.set_line_type(cr,"nondef")
 end
 
+@testset "reset_transform" begin
+
+    z = zeros(UInt32,512,512);
+    surf = CairoImageSurface(z, Cairo.FORMAT_ARGB32)
+
+    @test Cairo.status(surf) == 0
+
+    pa = surf.ptr
+    surf.ptr = C_NULL
+
+    @test destroy(surf) == nothing
+
+    surf.ptr = pa
+    cr = Cairo.CairoContext(surf)
+
+    m1 = CairoMatrix(1, 0, 0, 1, 0, 0)
+    m2 = CairoMatrix(1.0,2.0,2.0,1.0,0.,0.)
+    m = get_matrix(cr)
+    @test m == m1
+    set_matrix(cr, m2)
+    @test get_matrix(cr) == m2
+    Graphics.reset_transform(cr)
+    @test get_matrix(cr) == m1
+    @test destroy(cr) == nothing
+end
+
 nothing


### PR DESCRIPTION
A recent Cairo update seems to have caused troubles for ImageView due to `reset_transform` from `Graphics` not being imported. It's fixed by the `importall` on master; this just adds a test to make sure it doesn't regress.