### PR TITLE
remove Homebrew check

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -3,7 +3,6 @@ using BinDeps
 using Compat
 import Compat.Libdl
 import Compat.Sys
-import Compat.Pkg
 
 @BinDeps.setup
 
@@ -40,9 +39,6 @@ if Sys.iswindows()
 end
 
 if is_apple()
-    if Pkg.installed("Homebrew") === nothing
-        error("Homebrew package not installed, please run Pkg.add(\"Homebrew\")")
-    end
     using Homebrew
     provides( Homebrew.HB, "cairo", cairo, os = :Darwin )
     provides( Homebrew.HB, "pango", [pango, pangocairo], os = :Darwin, onload =


### PR DESCRIPTION
This doesn't work on v0.7 because `Pkg.installed` doesn't take a String anymore. While it could be fixed with Compat I propose to remove the check since the error message for `using Homebrew` is very similar and we don't do the check for windows. Homebrew is also in `REQUIRE` so it should be installed.