### PR TITLE
Import missing functions from Graphics.

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -13,7 +13,7 @@ using Colors
 
 import Graphics
 using Graphics: BoundingBox, GraphicsContext, GraphicsDevice
-import Graphics: arc, clip, close_path, creategc, fill_preserve, height, line_to, move_to, new_path, new_sub_path, paint, rectangle, rel_line_to, reset_clip, restore, rotate, save, scale, set_dash, set_line_width, set_source, set_source_rgb, set_source_rgba, stroke, stroke_preserve, textwidth, translate, width, circle, reset_transform
+import Graphics: arc, clip, clip_preserve, close_path, creategc, device_to_user!, device_to_user_distance!, fill_preserve, height, line_to, move_to, new_path, new_sub_path, paint, rectangle, rel_line_to, rel_move_to, reset_clip, restore, rotate, save, scale, set_dash, set_line_width, set_source, set_source_rgb, set_source_rgba, stroke, stroke_preserve, stroke_transformed, stroke_transformed_preserve, textwidth, translate, user_to_device!, user_to_device_distance!, width, circle, reset_transform
 import Base: copy, fill
 
 libcairo_version = VersionNumber(unsafe_string(


### PR DESCRIPTION
In #216, `importall Graphics` was converted to a list of more specific imports, since `importall` was being deprecated. That list is not complete, however, as can be witnessed by
```
julia> import Cairo, Graphics

julia> filter(x -> getfield(Graphics, x) != getfield(Cairo, x),
              intersect(names(Graphics), names(Cairo)))
8-element Array{Symbol,1}:
 :clip_preserve              
 :device_to_user!            
 :device_to_user_distance!   
 :rel_move_to                
 :stroke_transformed         
 :stroke_transformed_preserve
 :user_to_device!            
 :user_to_device_distance!   
julia> import Cairo, Graphics
```
One effect of this is that `text` function
```
function text(ctx::CairoContext, x::Real, y::Real, str::AbstractString;
              halign::AbstractString = "left", valign::AbstractString = "bottom", angle::Real = 0, markup::Bool=false)
    move_to(ctx, x, y)
    save(ctx)
    reset_transform(ctx)
    rotate(ctx, -angle*pi/180.)

    set_text(ctx, str, markup)
    update_layout(ctx)

    extents = get_layout_size(ctx)
    dxrel = -align2offset(halign)
    dyrel = align2offset(valign)
    rel_move_to(ctx, dxrel*extents[1], -dyrel*extents[2])

    show_layout(ctx)
    restore(ctx)
    w, h = Graphics.device_to_user(ctx, extents[1], extents[2])
    BoundingBox(x+dxrel*w, x+(dxrel+1)*w, y-dyrel*h, y+(1-dyrel)*h)
end
```
computes a bogus bounding box when device and user coordinates are not the same. `Graphics.device_to_user` is a thin wrapper that repackages the data and calls `device_to_user!`. This is supposed to dispatch back to Cairo but since `Cairo.device_to_user!` is currently a separate function from `Graphics.device_to_user!`, instead the do nothing fallback definition in `Graphics` is used and coordinates are not transformed.

This PR adds all those missing functions to the import list.
