### PR TITLE
Revert "Fix Homebrew issues on 0.7 and 1.0 (#250)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ matrix:
        - language: julia
          julia: 1.0
          os: osx
+    allow_failures:
+       - julia: 1.0
 notifications:
     email: false
 after_success:

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -39,7 +39,6 @@ end
 
 if Sys.isapple()
     using Homebrew
-    Homebrew.add("graphite2")
     provides( Homebrew.HB, "cairo", cairo, os = :Darwin )
     provides( Homebrew.HB, "pango", [pango, pangocairo], os = :Darwin, onload =
     """


### PR DESCRIPTION
This reverts commit 2017ef48c1b69af3a81cdadf6292f3853ae597ca. In issue #250 it was noted that the fix this reverts was not the right fix; while in practice it has the benefit of getting things working for people, it's useful to have an audience of mac users held captive (#230) so that someone is motivated to fix this for real. :laughing: 
