### PR TITLE
Add gettext alias for OpenSUSE Zypper

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -10,7 +10,7 @@ deps = [
     libpng = library_dependency("png", aliases = ["libpng","libpng-1.5.14","libpng15","libpng12.so.0","libpng12"], runtime = false, group = group)
     pixman = library_dependency("pixman", aliases = ["libpixman","libpixman-1","libpixman-1-0","libpixman-1.0"], depends = [libpng], runtime = false, group = group)
     libffi = library_dependency("ffi", aliases = ["libffi"], runtime = false, group = group)
-    gettext = library_dependency("gettext", aliases = ["libintl", "preloadable_libintl", "libgettextpo"], os = :Unix, group = group)
+    gettext = library_dependency("gettext", aliases = ["libintl", "preloadable_libintl", "libgettextpo","intltool"], os = :Unix, group = group)
     gobject = library_dependency("gobject", aliases = ["libgobject-2.0-0", "libgobject-2.0", "libgobject-2_0-0", "libgobject-2.0.so.0"], depends=[libffi, gettext], group = group)
     freetype = library_dependency("freetype", aliases = ["libfreetype"], runtime = false, group = group)
     fontconfig = library_dependency("fontconfig", aliases = ["libfontconfig-1", "libfontconfig", "libfontconfig.so.1"], depends = [freetype], runtime = false, group = group)


### PR DESCRIPTION
OpenSUSE Zypper seems to use both "gettext-runtime" and "intltool" packages to cover gettext. intltool is not installed in OpenSUSE by default. Installing intltool and adding new intltool alias for gettext seems to resolve an issue on my computer where even though gettext-runtime is installed, Julia reports that gettext is not installed. I believe the call to gettext is requiring functionality from the intltool package.