### PR TITLE
temporary: patch segfault on mac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,5 @@
 matrix:
     include:
-#       - language: julia
-#         julia: 0.6
-#         os: linux
-#         dist: trusty
-#         sudo: false
-#       - language: julia
-#         julia: 0.7
-#         os: linux
-#         dist: trusty
-#         sudo: false
-#       - language: julia
-#         julia: 1.0
-#         os: linux
-#         dist: trusty
-#         sudo: false
        - language: julia
          julia: 0.6
          os: linux
@@ -29,16 +14,15 @@ matrix:
          os: linux
 
        - language: julia
-         julia: 0.6
-         os: osx
-       - language: julia
          julia: 0.7
          os: osx
        - language: julia
          julia: 1.0
          os: osx
-    allow_failures:
-       - julia: 1.0
+       - language: julia
+         julia: 1.1
+         os: osx
+         
 notifications:
     email: false
 after_success:

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,6 +4,17 @@ using Compat
 import Compat.Libdl
 import Compat.Sys
 
+if Sys.isapple()
+    deps_file_str = open(joinpath(dirname(pathof(BinDeps)), "dependencies.jl")) do file
+        read(file, String)
+    end
+    if occursin("ZEval",pathof(BinDeps))
+        patched_dlclose = replace(deps_file_str, "Libdl.dlclose(h)" => "println(\"ignored: dlclose()\")")
+        include_string(BinDeps,patched_dlclose)
+    end
+end
+
+
 @BinDeps.setup
 
 # check for cairo version
@@ -166,3 +177,9 @@ provides(BuildProcess,
                        (:cairo, :_jl_libcairo),
                        (:pango, :_jl_libpango),
                        (:pangocairo, :_jl_libpangocairo)])
+
+
+if Sys.isapple()
+    import Pkg.Types.printpkgstyle
+    printpkgstyle(stdout, :Installed, "Patched install script, restarting Julia is recommended.")
+end


### PR DESCRIPTION
discussed [here](https://github.com/JuliaGraphics/Cairo.jl/issues/271), and also on upstream glib [here](https://gitlab.gnome.org/GNOME/pango/issues/363), using `dlopen/dlclose` is not supported by glib, but is used by BinDeps; suggested in https://github.com/JuliaPackaging/BinDeps.jl/issues/397 and verified by `print(getpid())`, the build process is run in another pid, therefore not using `dlclose` may be ok, patched with the new build.jl: only patch for macos and only patch the current version of BinDeps (`occursin("ZEval",pathof(BinDeps))`)

julia: 0.6 removed in .travis.yml since pathof is not available there, feel free to disregard

temporary until maybe https://github.com/JuliaGraphics/Cairo.jl/pull/229 is finished?