### PR TITLE
adds back v0.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
          os: linux
 
        - language: julia
+         julia: 0.6
+         os: osx
+       - language: julia
          julia: 0.7
          os: osx
        - language: julia

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,10 +5,11 @@ import Compat.Libdl
 import Compat.Sys
 
 if Sys.isapple()
-    deps_file_str = open(joinpath(dirname(pathof(BinDeps)), "dependencies.jl")) do file
+    bindeps_path = VERSION >= v"0.7" ? joinpath(dirname(pathof(BinDeps)), "dependencies.jl") : joinpath(Pkg.dir("BinDeps"),"src/dependencies.jl")
+    deps_file_str = open(bindeps_path) do file
         read(file, String)
     end
-    if occursin("ZEval",pathof(BinDeps))
+    if occursin("ZEval",bindeps_path) || VERSION < v"0.7"
         patched_dlclose = replace(deps_file_str, "Libdl.dlclose(h)" => "println(\"ignored: dlclose()\")")
         include_string(BinDeps,patched_dlclose)
     end


### PR DESCRIPTION
Adds to my previous PR https://github.com/JuliaGraphics/Cairo.jl/pull/274 so that julia v0.6 support is added back.  Feel free to change/discard :-)

Julia is a relatively "young" and very actively developed language, so it's subject to changes every now and then; personally, I'm all for keeping up with the current stable release, but reading from the comments it looks like support for v0.6 is advised.