### PR TITLE
Support Colors 0.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Pango_jll = "36c8627f-9965-5494-a995-c6b170f724f3"
 [compat]
 julia = "1.3"
 Cairo_jll = "1.16.0"
-Colors = "0.9, 0.10, 0.11"
+Colors = "0.9, 0.10, 0.11, 0.12"
 Fontconfig_jll = "2.13.1"
 Glib_jll = "2.59.0"
 Graphics = "0.4, 1"


### PR DESCRIPTION
I've tested this locally and it passes tests. In the Travis logs it's worth checking whether it actually uses this version, though.

We might want to install https://github.com/bcbi/CompatHelper.jl, though https://github.com/bcbi/CompatHelper.jl/issues/160 is pretty annoying. But since Cairo's dependencies are pretty minimal, I doubt it will be that much of a problem here (it comes up much more often in packages with lots of dependencies).