### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@
 
 Adaptation to [Cairo](https://www.cairographics.org/), a 2D graphics library with support for multiple output devices. 
 
-Some of the functions implemented by this wrapper may be documented in [Base.Graphics](http://docs.julialang.org/en/release-0.3/stdlib/graphics/).
+Some of the functions implemented by this wrapper may be documented in [Graphics.jl](https://juliagraphics.github.io/Graphics.jl/stable/).
 
 There is an extensive set of [examples](samples/Samples.md).


### PR DESCRIPTION
The url of Julia v0.3 documentation has been changed to https://docs.julialang.org/en/v0.3/stdlib/graphics/. (release-0.3 --> v0.3)
This changes the reference from Base.Graphics to Graphics.jl, although the documentation for Graphics.jl is still incomplete.