### PR TITLE
Make height and width inferrable for (abstract) CairoSurface

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -169,6 +169,18 @@ get_readstream_callback(::Type{T}) where T = @cfunction read_from_stream_callbac
 
 abstract type CairoSurface{T<:Union{UInt32,RGB24,ARGB32}} <: GraphicsDevice end
 
+# All CairoSurfaces have to implement at least the fields and types of CairoSurfaceBase
+function Base.getproperty(surface::CairoSurface, fieldname::Symbol)
+    if fieldname === :ptr
+        return getfield(surface, :ptr)::Ptr{Nothing}
+    elseif fieldname === :width
+        return getfield(surface, :width)::Float64
+    elseif fieldname === :height
+        return getfield(surface, :height)::Float64
+    end
+    return getfield(surface, fieldname)
+end
+
 mutable struct CairoSurfaceBase{T<:Union{UInt32,RGB24,ARGB32}} <: CairoSurface{T}
     ptr::Ptr{Nothing}
     width::Float64

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,11 +17,14 @@ end
 @testset "Image Surface  " begin
 
     surf = CairoImageSurface(100, 200, Cairo.FORMAT_ARGB32)
-    @test width(surf) == 100
-    @test height(surf) == 200
+    @test @inferred(width(surf)) == 100
+    @test @inferred(height(surf)) == 200
+    abstractsurf = Ref{CairoSurface}(surf)
+    @test @inferred(width(abstractsurf[])) == 100
+    @test @inferred(height(abstractsurf[])) == 200
     ctx = CairoContext(surf)
-    @test width(ctx) == 100
-    @test height(ctx) == 200
+    @test @inferred(width(ctx)) == 100
+    @test @inferred(height(ctx)) == 200
 
     surf = CairoImageSurface(fill(RGB24(0), 10, 10))
     @test Cairo.format(surf) == RGB24
@@ -245,7 +248,7 @@ end
         @test length(d) == 1
         @test collect(keys(d))[1] == 0x80000080
 
-        
+
     end
 end
 


### PR DESCRIPTION
Gtk.jl and other libraries have containers with fields that are
typed abstractly as `::CairoSurface`. This allows `width` and
`height` to be inferrable even for the abstract type.
It enforces an "interface" expected of all CairoSurface subtypes.