### PR TITLE
Support for cairo_image_surface_get_data (#342)

### DIFF
--- a/src/Cairo.jl
+++ b/src/Cairo.jl
@@ -271,6 +271,12 @@ for name in (:finish,:flush,:mark_dirty)
     end
 end
 
+function image_surface_get_data(surface::CairoSurface{T}) where {T}
+    return ccall(
+        (:cairo_image_surface_get_data, libcairo),
+        Ptr{T}, (Ptr{Nothing},), surface.ptr)
+end
+
 function status(surface::CairoSurface)
     ccall((:cairo_surface_status,libcairo),
           Int32, (Ptr{Nothing},), surface.ptr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -281,6 +281,16 @@ end
     d = simple_hist(d1)
 
     @test length(d) == 512 # black is included
+
+    # width: 5, height: 3; Test-Image
+    mat = [ 0x80800000  0x00000000  0x00000000
+            0x80800000  0x00000000  0x00000000
+            0x80800000  0x33000033  0x33000033
+            0x80800000  0x33000033  0x33000033
+            0xff00ff00  0xff00ff00  0x00000000 ]
+    surf = CairoImageSurface(mat, Cairo.FORMAT_ARGB32; flipxy=false)
+    data_arr = unsafe_wrap(Array, Cairo.image_surface_get_data(surf), (5, 3))
+    @test (mat == data_arr) && (mat == surf.data)
 end
 
 @testset "Assert/Status  " begin


### PR DESCRIPTION
Try to add support for Cairo's `cairo_image_surface_get_data`.

Added one test for new function.
