### PR TITLE
Update version to 1.1 in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Cairo"
 uuid = "159f3aea-2a34-519c-b102-8c37f9878175"
-version = "1.0.5"
+version = "1.1"
 
 [deps]
 Cairo_jll = "83423d85-b0ee-5818-9007-b63ccbeb887a"
@@ -11,11 +11,11 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 Pango_jll = "36c8627f-9965-5494-a995-c6b170f724f3"
 
 [compat]
-julia = "1.3"
-Cairo_jll = "1.16.0"
-Colors = "0.9, 0.10, 0.11, 0.12"
+julia = "1.6"
+Cairo_jll = "1.16"
+Colors = "0.12"
 Glib_jll = "2.59.0"
-Graphics = "0.4, 1"
+Graphics = "1"
 Pango_jll = "1.42.4"
 
 [extras]


### PR DESCRIPTION
Bumping up dependencies for very old versions. Perhaps this can be done more aggressively.

Does someone have views on Cairo, Pango, and Glib? In general those builds made a lot of improvements in the last few versions and it may be nice to set a new minimum. Example: https://github.com/JuliaGraphics/Cairo.jl/issues/363#issuecomment-2220273451